### PR TITLE
Add Portable v69.0.3497.100-2

### DIFF
--- a/config/platforms/linux_portable/64bit/69.0.3497.100-2.ini
+++ b/config/platforms/linux_portable/64bit/69.0.3497.100-2.ini
@@ -2,10 +2,10 @@
 status = development
 publication_time = 2018-10-04T00:17:40.773894
 github_author = Intika
-note = Portable Linux Built On An Opensuse v42.3 VM
+note = Portable Linux Built On An Opensuse v42.3 VM (file hosted on Opendesktop.org)
 
-[ungoogled-chromium_69.0.3497.100-2_linux.tar.xz]
-url = https://github.com/intika/ungoogled-chromium-binaries/releases/download/69.0.3497.100-2/ungoogled-chromium_69.0.3497.100-2_linux.tar.xz
+[opendesktop.org_ungoogled-chromium_69.0.3497.100-2]
+url = https://www.opendesktop.org/p/1265177/
 md5 = e8205d10c88256b94b22e07535ff36c7
 sha1 = 6a05fa31287f74e59b079fbd32d4f14f9d3111a1
 sha256 = da7ed55c0ef7ba74b2d365fc63b92d3eb3e0310b8b9c52855010c6620f9d1cb5

--- a/config/platforms/linux_portable/64bit/69.0.3497.100-2.ini
+++ b/config/platforms/linux_portable/64bit/69.0.3497.100-2.ini
@@ -1,0 +1,11 @@
+[_metadata]
+status = development
+publication_time = 2018-10-04T00:17:40.773894
+github_author = Intika
+note = Portable Linux Built On An Opensuse v42.3 VM
+
+[ungoogled-chromium_69.0.3497.100-2_linux.tar.xz]
+url = https://github.com/intika/ungoogled-chromium-binaries/releases/download/69.0.3497.100-2/ungoogled-chromium_69.0.3497.100-2_linux.tar.xz
+md5 = e8205d10c88256b94b22e07535ff36c7
+sha1 = 6a05fa31287f74e59b079fbd32d4f14f9d3111a1
+sha256 = da7ed55c0ef7ba74b2d365fc63b92d3eb3e0310b8b9c52855010c6620f9d1cb5

--- a/feed.xml
+++ b/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title type="text">ungoogled-chromium Binary Downloads</title>
   <id>https://ungoogled-software.github.io/ungoogled-chromium-binaries/feed.xml</id>
-  <updated>2018-10-04T22:14:21Z</updated>
+  <updated>2018-10-04T00:17:40Z</updated>
   <link href="https://ungoogled-software.github.io/ungoogled-chromium-binaries/" />
   <link href="https://ungoogled-software.github.io/ungoogled-chromium-binaries/feed.xml" rel="self" />
   <subtitle type="text">Feed of contributor-submitted binaries</subtitle>

--- a/feed.xml
+++ b/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title type="text">ungoogled-chromium Binary Downloads</title>
   <id>https://ungoogled-software.github.io/ungoogled-chromium-binaries/feed.xml</id>
-  <updated>2018-09-29T22:14:21Z</updated>
+  <updated>2018-10-04T22:14:21Z</updated>
   <link href="https://ungoogled-software.github.io/ungoogled-chromium-binaries/" />
   <link href="https://ungoogled-software.github.io/ungoogled-chromium-binaries/feed.xml" rel="self" />
   <subtitle type="text">Feed of contributor-submitted binaries</subtitle>
@@ -50,10 +50,10 @@
 &lt;/p&gt;</content>
   </entry>
   <entry xml:base="https://ungoogled-software.github.io/ungoogled-chromium-binaries/feed.xml">
-    <title type="text">Portable Linux 64-bit: 69.0.3497.100-1 (development)</title>
-    <id>2018-09-20T00:17:40.773894+00:0069.0.3497.100-1developmentPortableLinux64-bit</id>
-    <updated>2018-09-20T00:17:40Z</updated>
-    <link href="https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-1" />
+    <title type="text">Portable Linux 64-bit: 69.0.3497.100-2 (development)</title>
+    <id>2018-10-04T00:17:40.773894+00:0069.0.3497.100-2developmentPortableLinux64-bit</id>
+    <updated>2018-10-04T00:17:40Z</updated>
+    <link href="https://ungoogled-software.github.io/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-2" />
     <author>
       <name></name>
     </author>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 <tr>
 <td align="left"><strong><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit">Portable Linux 64-bit</a></strong></td>
 <td align="left"><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/67.0.3396.87-2">67.0.3396.87-2</a></td>
-<td align="left"><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-1">69.0.3497.100-1</a></td>
+<td align="left"><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-2">69.0.3497.100-2</a></td>
 </tr>
 <tr>
 <td align="left"><strong><a href="/ungoogled-chromium-binaries/releases/macos">macOS</a></strong></td>

--- a/releases/linux_portable/64bit/69.0.3497.100-2.html
+++ b/releases/linux_portable/64bit/69.0.3497.100-2.html
@@ -1,0 +1,36 @@
+<html>
+<head>
+<meta charset="UTF-8"></meta>
+<title>69.0.3497.100-2: Binaries for Portable Linux 64-bit</title>
+<link rel="stylesheet" href="/ungoogled-chromium-binaries/github-markdown.css"></link>
+<style>
+    .markdown-body {
+        box-sizing: border-box;
+        min-width: 0%;
+        max-width: 100%;
+        margin: 0 auto;
+        padding: 2em;
+    }
+</style>
+</head>
+<body class="markdown-body">
+<h1>69.0.3497.100-2: Binaries for Portable Linux 64-bit</h1>
+<p>Navigation: <a href="/ungoogled-chromium-binaries/">Front page</a> / <a href="/ungoogled-chromium-binaries/releases/">Releases</a> / <a href="/ungoogled-chromium-binaries/releases/linux_portable">Portable Linux</a> / <a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit">64-bit</a> / <a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-2">69.0.3497.100-2</a></p>
+<h2>Release Information</h2>
+<ul>
+<li>Author: <a href="//github.com/Intika">Intika</a> (<a href="//github.com/Intika/ungoogled-chromium-binaries/releases">view all releases from user</a>)</li>
+<li>Publication time (in UTC): <code>2018-10-04 00:17:40.773894+00:00</code></li>
+<li>Notes: Portable Linux Built On An Opensuse v42.3 VM</li>
+</ul>
+<p>Status: <strong>Development</strong></p>
+<h2>Downloads</h2>
+<ul>
+<li><a href="https://www.opendesktop.org/p/1265177/" target="_blank">ungoogled-chromium_69.0.3497.100-2_linux.tar.xz</a><ul>
+<li>MD5: <code>e8205d10c88256b94b22e07535ff36c7</code></li>
+<li>SHA1: <code>6a05fa31287f74e59b079fbd32d4f14f9d3111a1</code></li>
+<li>SHA256: <code>da7ed55c0ef7ba74b2d365fc63b92d3eb3e0310b8b9c52855010c6620f9d1cb5</code></li>
+</ul>
+</li>
+</ul>
+</body>
+</html>

--- a/releases/linux_portable/64bit/69.0.3497.100-2.html
+++ b/releases/linux_portable/64bit/69.0.3497.100-2.html
@@ -20,12 +20,12 @@
 <ul>
 <li>Author: <a href="//github.com/Intika">Intika</a> (<a href="//github.com/Intika/ungoogled-chromium-binaries/releases">view all releases from user</a>)</li>
 <li>Publication time (in UTC): <code>2018-10-04 00:17:40.773894+00:00</code></li>
-<li>Notes: Portable Linux Built On An Opensuse v42.3 VM</li>
+<li>Notes: Portable Linux Built On An Opensuse v42.3 VM (file hosted on Opendesktop.org)</li>
 </ul>
 <p>Status: <strong>Development</strong></p>
 <h2>Downloads</h2>
 <ul>
-<li><a href="https://www.opendesktop.org/p/1265177/" target="_blank">ungoogled-chromium_69.0.3497.100-2_linux.tar.xz</a><ul>
+<li><a href="https://www.opendesktop.org/p/1265177/">opendesktop.org_ungoogled-chromium_69.0.3497.100-2</a><ul>
 <li>MD5: <code>e8205d10c88256b94b22e07535ff36c7</code></li>
 <li>SHA1: <code>6a05fa31287f74e59b079fbd32d4f14f9d3111a1</code></li>
 <li>SHA256: <code>da7ed55c0ef7ba74b2d365fc63b92d3eb3e0310b8b9c52855010c6620f9d1cb5</code></li>

--- a/releases/linux_portable/64bit/index.html
+++ b/releases/linux_portable/64bit/index.html
@@ -18,6 +18,7 @@
 <p>Navigation: <a href="/ungoogled-chromium-binaries/">Front page</a> / <a href="/ungoogled-chromium-binaries/releases/">Releases</a> / <a href="/ungoogled-chromium-binaries/releases/linux_portable">Portable Linux</a> / <a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit">64-bit</a></p>
 <h2>Available versions</h2>
 <ul>
+<li><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-2">69.0.3497.100-2</a></li>
 <li><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/69.0.3497.100-1">69.0.3497.100-1</a></li>
 <li><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/68.0.3440.106-2">68.0.3440.106-2</a></li>
 <li><a href="/ungoogled-chromium-binaries/releases/linux_portable/64bit/67.0.3396.87-2">67.0.3396.87-2</a></li>


### PR DESCRIPTION
Following https://github.com/ungoogled-software/ungoogled-chromium-binaries/issues/26 i have linked the tar.xz to opendesktop.org under the file 69.0.3497.100-2.html let me know if i can and also if i can post my builds binary on opendesktop.org (otherwise i will remove it) 
Thanks :)