### PR TITLE
Promote macOS 70.0.3538.77-1 to release

### DIFF
--- a/config/platforms/macos/70.0.3538.77-1.ini
+++ b/config/platforms/macos/70.0.3538.77-1.ini
@@ -1,5 +1,5 @@
 [_metadata]
-status = development
+status = release
 publication_time = 2018-10-29T15:28:36.211461
 github_author = chase9
 # Add a `note` field here for additional information. Markdown is supported


### PR DESCRIPTION
I believe this is reasonable as other platforms have promoted this version to release, and we have been 2+ weeks without issues filed.