### PR TITLE
Add 71.0.3578.98-2 binaries for Arch Linux

### DIFF
--- a/config/platforms/archlinux/71.0.3578.98-2.ini
+++ b/config/platforms/archlinux/71.0.3578.98-2.ini
@@ -1,0 +1,11 @@
+[_metadata]
+status = development
+publication_time = 2018-12-19T07:20:30.367738
+github_author = rtMis
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-71.0.3578.98-2-x86_64.pkg.tar.xz]
+url = https://github.com/rtMis/ungoogled-chromium-binaries/releases/download/71.0.3578.98-2/ungoogled-chromium-71.0.3578.98-2-x86_64.pkg.tar.xz
+md5 = 77dfe88203185b195ae5b18a4107f733
+sha1 = ba48496ba8e59160c5f8d80b71a1f80d7293fa91
+sha256 = d4e3e8e21e00c77f227ba7c1cfb9a2ee23e8d84248db52382ebb48818b76c139


### PR DESCRIPTION
ungoogled-chromium-71.0.3578.98-2-x86_64.pkg.tar.xz added for Arch Linux