### PR TITLE
72.0.3626.109-1 macOS binary as dev, 71.0.3578.98-2 to release

### DIFF
--- a/config/platforms/macos/71.0.3578.98-2.ini
+++ b/config/platforms/macos/71.0.3578.98-2.ini
@@ -1,5 +1,5 @@
 [_metadata]
-status = development
+status = release
 publication_time = 2018-12-26T10:40:19.710743
 github_author = kramred
 # Add a `note` field here for additional information. Markdown is supported

--- a/config/platforms/macos/72.0.3626.109-1.ini
+++ b/config/platforms/macos/72.0.3626.109-1.ini
@@ -1,0 +1,11 @@
+[_metadata]
+status = development
+publication_time = 2019-02-21T19:29:58.446485
+github_author = kramred
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_72.0.3626.109-1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-binaries/releases/download/72.0.3626.109-1/ungoogled-chromium_72.0.3626.109-1_macos.dmg
+md5 = b3eab32efee7a4a79a99e966a779eff4
+sha1 = 90e8d635a4362cd6d8c99942891b0499406284c4
+sha256 = 8a2421dafeb1ed0225391770a14186f5006017d01f8869d98526deb4c29e8b0b


### PR DESCRIPTION
add 72.0.3626.109-1 macOS binary based on commit [a58db88](https://github.com/Eloston/ungoogled-chromium/commit/a58db880c15e5077e881cad7b07d1a277ecd463a) from 2019-02-17

And shift 71.0.3578.98-2 to release version