### PR TITLE
72.0.3626.122-1 for macOS

### DIFF
--- a/config/platforms/macos/72.0.3626.122.ini
+++ b/config/platforms/macos/72.0.3626.122.ini
@@ -1,0 +1,12 @@
+[_metadata]
+status = development
+publication_time = 2019-03-08T20:50:57.872088
+github_author = chase9
+# Add a `note` field here for additional information. Markdown is supported
+**Please note** this version is our first build since [this vuln](https://www.extremetech.com/internet/287196-google-discovers-zero-day-vulnerability-in-chrome) was reported. As such we might want to consider speeding up getting this build into release.
+
+[ungoogled-chromium_72.0.3626.122-1_macos.dmg]
+url = https://github.com/chase9/ungoogled-chromium-binaries/releases/download/72.0.3626.122/ungoogled-chromium_72.0.3626.122-1_macos.dmg
+md5 = 05ee22467256f2ddf15c8fa28edc7a58
+sha1 = abb53243385beff1e28a1b62743b07e3a77baa16
+sha256 = 31787eb01990470470038af434967a1b452eeedbd2924619bef0dfc20aa72560


### PR DESCRIPTION
**Please note** this version is our first build since [this vuln](https://www.extremetech.com/internet/287196-google-discovers-zero-day-vulnerability-in-chrome) was reported. As such we might want to consider speeding up getting this build into release.