### PR TITLE
Add 73.0.3683.103-1.disco1 for Ubuntu disco amd64

### DIFF
--- a/config/platforms/ubuntu/disco_amd64/73.0.3683.103-1.disco1.ini
+++ b/config/platforms/ubuntu/disco_amd64/73.0.3683.103-1.disco1.ini
@@ -1,0 +1,53 @@
+[_metadata]
+status = development
+publication_time = 2019-04-24T08:40:47.945155
+github_author = riyad
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-common_73.0.3683.103-1.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium-common_73.0.3683.103-1.disco1_amd64.deb
+md5 = f1c8c847b6e77fb7e835bdf98f777a21
+sha1 = a2f5531bfeb4a4a8b3147acdce0ccf3e136156cc
+sha256 = ba0a971bb0f78eda64548be42d4b5fce629589ff8d2bb6c30a67afeee26fefab
+
+[ungoogled-chromium-driver_73.0.3683.103-1.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium-driver_73.0.3683.103-1.disco1_amd64.deb
+md5 = 0ae3c1304657586199447830fdee670c
+sha1 = 1b01be252902fdba1a73af79b75147ca25afe9d8
+sha256 = 836bff3c5127afa9b57074228394eccc960cefb121ebef22cf23879b73be801f
+
+[ungoogled-chromium-l10n_73.0.3683.103-1.disco1_all.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium-l10n_73.0.3683.103-1.disco1_all.deb
+md5 = daa6b528fab69c4687919b2cd8f17cc0
+sha1 = 7a5107bd6b13d64ba309f481ab2e2d6ff8d27b7c
+sha256 = 3d78f57fcd8d1c9787759e8b3c17d0ab7f2b9eb99a720e63ecf1bd9a0bd80c0e
+
+[ungoogled-chromium-sandbox_73.0.3683.103-1.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium-sandbox_73.0.3683.103-1.disco1_amd64.deb
+md5 = a8c05d8fd601d0fab58978bb7b633f60
+sha1 = e85b2e61205cd23eb72b4eb75b25d1a4f0cfa4ed
+sha256 = 34e1d04b80df9ee6a6426d43f17067d1bc172deb71c74206a97e9cc4d35ba75b
+
+[ungoogled-chromium-shell_73.0.3683.103-1.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium-shell_73.0.3683.103-1.disco1_amd64.deb
+md5 = 4f09531753912d438e6d2e260037891f
+sha1 = 87fa68c46fb34efbc2fbdc1831d8e9d57fe60988
+sha256 = 2aa28b6e0ec8a4b828498d078bb3ec8f96caf65991fb9810af1d6ee612944f41
+
+[ungoogled-chromium_73.0.3683.103-1.disco1_amd64.buildinfo]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium_73.0.3683.103-1.disco1_amd64.buildinfo
+md5 = 72cfa5f778305c69877042335851d5e7
+sha1 = 7011b1c58ce6664666ac30765920be883a57eb49
+sha256 = e8ed5220e623f6fb46f07c0e8c9d40c70cc9038444e128acf3621cf98396be91
+
+[ungoogled-chromium_73.0.3683.103-1.disco1_amd64.changes]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium_73.0.3683.103-1.disco1_amd64.changes
+md5 = 8cee65c8fb58c099130af5d505b9a018
+sha1 = e294722d3b02b6dcfec548b20a01c1c609c9d4f9
+sha256 = 2ef950a65c0821ff248e65095ac2ba30c94bd2543ccc1612635131ba4026d4fb
+
+[ungoogled-chromium_73.0.3683.103-1.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/73.0.3683.103-1.disco1/ungoogled-chromium_73.0.3683.103-1.disco1_amd64.deb
+md5 = 0a2e30d16032ba07c21767a0a843ed31
+sha1 = 391841828bf4cd3c1ff31d7f4d571e6f4183ee1e
+sha256 = 22ff90c4190137608fc8b145311dbe984b1975300449c32fbf157b7157f68515


### PR DESCRIPTION
based on https://github.com/ungoogled-software/ungoogled-chromium-debian/pull/10

Please also add the `73.0.3683.103-1.disco1` tag to the [ungoogled-chromium-debian](https://github.com/ungoogled-software/ungoogled-chromium-debian) repo. :slightly_smiling_face: 