### PR TITLE
Add 74.0.3729.131-1 binaries for Arch Linux

### DIFF
--- a/config/platforms/archlinux/74.0.3729.131-1.ini
+++ b/config/platforms/archlinux/74.0.3729.131-1.ini
@@ -1,0 +1,11 @@
+[_metadata]
+status = development
+publication_time = 2019-05-03T13:06:56.790479
+github_author = tangalbert919
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-74.0.3729.131-1-x86_64.pkg.tar.xz]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/74.0.3729.131-1/ungoogled-chromium-74.0.3729.131-1-x86_64.pkg.tar.xz
+md5 = 676747f5cd1e355495c3d31643b3919f
+sha1 = 9af39a95b95b72bb443ab20c9ad2a2675a649ebe
+sha256 = d5f9c7abc94c4540b37c374c8044b7f71f5c67d6a71033a16c7a706904fd4d48


### PR DESCRIPTION
No changes were required for [ungoogled-chromium-archlinux](https://github.com/ungoogled-software/ungoogled-chromium-archlinux) to build this.

EDIT: Actually, updating `_ungoogled_version` is one change required for this, but that's about it.