### PR TITLE
74.0.3729.131-1.1 macOS: fix issues with Homebrew

### DIFF
--- a/config/platforms/macos/74.0.3729.131-1.ini
+++ b/config/platforms/macos/74.0.3729.131-1.ini
@@ -5,7 +5,7 @@ github_author = unpredictable
 # Add a `note` field here for additional information. Markdown is supported
 
 [ungoogled-chromium_74.0.3729.131-1.1_macos.dmg]
-url = https://github.com/unpredictable/ungoogled-chromium-binaries/releases/download/74.0.3729.131-1/ungoogled-chromium_74.0.3729.131-1.1_macos.dmg
+url = https://github.com/unpredictable/ungoogled-chromium-binaries/releases/download/74.0.3729.131-1.1/ungoogled-chromium_74.0.3729.131-1.1_macos.dmg
 md5 = c2980c1a276712ae935bcbc6be39e3f0
 sha1 = 830d2cadfecd83fe279dd7f7645dc9170135e381
 sha256 = ff91741de6bbe95cf4bb7f9ac85e3a0be3612707f3421b0c25f2b14e897e7a5c


### PR DESCRIPTION
Sorry, I was in a rush and forgot to add the .1 suffix, which broke Homebrew. I apologize. Nothing else has changed.