### PR TITLE
Add 75.0.3770.100-1.disco2 for Ubuntu disco amd64

### DIFF
--- a/config/platforms/ubuntu/disco_amd64/75.0.3770.100-1.disco2.ini
+++ b/config/platforms/ubuntu/disco_amd64/75.0.3770.100-1.disco2.ini
@@ -1,0 +1,53 @@
+[_metadata]
+status = development
+publication_time = 2019-06-24T18:04:54.618278
+github_author = riyad
+note = rebuilt to fix ICU library compatibility
+
+[ungoogled-chromium-common_75.0.3770.100-1.disco2_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium-common_75.0.3770.100-1.disco2_amd64.deb
+md5 = 0a5152d5fffd246b8103a923ed351fc7
+sha1 = 113bf62601c07f341418117c570a1359fc4a62fd
+sha256 = a86cd04e1c0a495b554827c8fe1b3b82fab35631e9a846327fd06189093a67da
+
+[ungoogled-chromium-driver_75.0.3770.100-1.disco2_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium-driver_75.0.3770.100-1.disco2_amd64.deb
+md5 = 0f14d3f4b7b2545ba5c48b963e398c79
+sha1 = 70b87abe09fc41fb8f6e62823523b7aedad314d1
+sha256 = 66e58c7f9083bd14c53cd81409e0ed19d783184c90ec02a0c96ff9b2530c6ab8
+
+[ungoogled-chromium-l10n_75.0.3770.100-1.disco2_all.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium-l10n_75.0.3770.100-1.disco2_all.deb
+md5 = 71155d3b8dd3437619a5764985f981c8
+sha1 = 1ea6c9d8517ed864c1aabb7da52fa4ba30238a35
+sha256 = 20f8bbb699ff9044e161305c41886903d228a4ae55857fa3ac59a63dad9f737d
+
+[ungoogled-chromium-sandbox_75.0.3770.100-1.disco2_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium-sandbox_75.0.3770.100-1.disco2_amd64.deb
+md5 = 6ac70b449f11ea2f6c12f1649b6dde4f
+sha1 = 58d0f48a18039b4e2b1bd1ce4c21151b846e194c
+sha256 = 38fb64bb7b78423e0f98ba38e21b57f14e6a763039bfa325cfe67f6cd252efee
+
+[ungoogled-chromium-shell_75.0.3770.100-1.disco2_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium-shell_75.0.3770.100-1.disco2_amd64.deb
+md5 = fc9b70c230819287790ca1b4a6b7067f
+sha1 = 60e5569a2f6f6d8ce73d13e230cf653ac856efd2
+sha256 = 4444a1b54dc27372e3b0f3f45fe992c9bff4311e89b2af77c8717362aea6d51a
+
+[ungoogled-chromium_75.0.3770.100-1.disco2_amd64.buildinfo]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium_75.0.3770.100-1.disco2_amd64.buildinfo
+md5 = 518dd09957e47dba595a4a05c44ea32b
+sha1 = 2c1ed9a99b29688cc883f8a26ef16a4f90c0dcf2
+sha256 = ab25d8f534e2627dab090e9d5d631715f0da8c41d5768e299ee617c214aa7d52
+
+[ungoogled-chromium_75.0.3770.100-1.disco2_amd64.changes]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium_75.0.3770.100-1.disco2_amd64.changes
+md5 = 60b9e92813c7d5ed3395e0a85a3c7969
+sha1 = 3cc03561cc25448e535546f4c066e760a41e2afb
+sha256 = 8ed514a62ca3b2eb3e95e652043a806d063892b5b0992e24f7cde17765ebfdd7
+
+[ungoogled-chromium_75.0.3770.100-1.disco2_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/75.0.3770.100-1.disco2/ungoogled-chromium_75.0.3770.100-1.disco2_amd64.deb
+md5 = 95d21b812737dac31fac4ed72d0053ee
+sha1 = 1a9963284ccf81c94a2dfe80f6ba69d3717c30ae
+sha256 = 261efa9371f3f5046b9302a26270e294c91460c527d56d9c15d31201d1308290


### PR DESCRIPTION
Based on https://github.com/ungoogled-software/ungoogled-chromium-debian/pull/17.

- rebuilt to fix ICU library compatibility