### PR TITLE
add 77.0.3865.120-1 macOS binary, built via GitHub Actions CI

### DIFF
--- a/config/platforms/macos/77.0.3865.120-1.ini
+++ b/config/platforms/macos/77.0.3865.120-1.ini
@@ -1,0 +1,12 @@
+[_metadata]
+status = development
+publication_time = 2019-10-14T12:02:31.882764
+github_author = kramred
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_77.0.3865.120-1.1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-binaries/releases/download/77.0.3865.120-1/ungoogled-chromium_77.0.3865.120-1.1_macos.dmg
+md5 = a8c9f92d127924ebc6bb4391dc46d603
+sha1 = a15c66f1ae2a921d061a7a3af87bc8c21fd4ccaf
+sha256 = 3197d136d6648eac6806e5b951788498b1cf5af9b57ff9629c522fb537f33119
+note = Build with GitHub Actions (CI), Binary from artifacts; see https://github.com/kramred/ungoogled-chromium-macos/commit/34cc901cc0a05b143b9df86e549bfa5226a90277/checks?check_suite_id=263750336


### PR DESCRIPTION
Build with GitHub Actions (CI), Binary from artifacts; see [here](https://github.com/kramred/ungoogled-chromium-macos/commit/34cc901cc0a05b143b9df86e549bfa5226a90277/checks?check_suite_id=263750336)