### PR TITLE
Add 78.0.3904.70-1 binaries for Arch Linux

### DIFF
--- a/config/platforms/archlinux/78.0.3904.70-1.ini
+++ b/config/platforms/archlinux/78.0.3904.70-1.ini
@@ -1,0 +1,11 @@
+[_metadata]
+status = development
+publication_time = 2019-10-29T13:02:36.067953
+github_author = jstkdng
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-78.0.3904.70-1-x86_64.pkg.tar.xz]
+url = https://github.com/jstkdng/ungoogled-chromium-binaries/releases/download/78.0.3904.70-1/ungoogled-chromium-78.0.3904.70-1-x86_64.pkg.tar.xz
+md5 = 3294a554997fdb95698d3bea7390c594
+sha1 = 19c3669096ccd3cd3b3e508ccdc8b0911ae565e5
+sha256 = 1a8063af413eafc10eaa9376f0b67f8ce4c7b356f0e215f61aa025d7debb4f04


### PR DESCRIPTION
I also had to edit the file utilities/platform_ini_generator.py to get it to work, probably because of arch, should I add that too?