### PR TITLE
Add 78.0.3904.97-2 binaries for Debian Buster

### DIFF
--- a/config/platforms/debian/buster_amd64/78.0.3904.97-2.ini
+++ b/config/platforms/debian/buster_amd64/78.0.3904.97-2.ini
@@ -1,0 +1,53 @@
+[_metadata]
+status = development
+publication_time = 2019-11-12T02:21:24.440113
+github_author = tangalbert919
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-common_78.0.3904.97-2.buster1_amd64.deb]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium-common_78.0.3904.97-2.buster1_amd64.deb
+md5 = a04fa7b7d4abf8465a1347b1c1c11da0
+sha1 = a575d2c7dffc7c139c7163f2760fbcd95e1e1b1e
+sha256 = 5b6c14473556eb6c16e9abf201732e43a177d0e1dbe318cd9ecfbd635d130948
+
+[ungoogled-chromium-driver_78.0.3904.97-2.buster1_amd64.deb]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium-driver_78.0.3904.97-2.buster1_amd64.deb
+md5 = c2cb6998c57cb8fa96f85fc6e23e7ce2
+sha1 = 54a554904a8bf1781c3e62c40591e50e02813ca6
+sha256 = e7723277a04090882bfb5e60a7ff3f5127f580d47a7b82cd5f5176b6231447a6
+
+[ungoogled-chromium-l10n_78.0.3904.97-2.buster1_all.deb]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium-l10n_78.0.3904.97-2.buster1_all.deb
+md5 = 08477e67b4e7a7ea146daafa23235592
+sha1 = 2d70eaa93eb3c5e0c3bda500871973ac27a9742e
+sha256 = de6891026b5fa9d406f51ce088bc3c57d24c3b6a5dbcb74a80773fa68947e7c8
+
+[ungoogled-chromium-sandbox_78.0.3904.97-2.buster1_amd64.deb]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium-sandbox_78.0.3904.97-2.buster1_amd64.deb
+md5 = a69281e34e722d889fd9bf75fc62cc47
+sha1 = c630f972a26c3924d8671c39af0aaf0366241fd3
+sha256 = f10b3a473729f6c5d7aa6e7b9d9a5751182b3028b0b2531ed36437ada924df5c
+
+[ungoogled-chromium-shell_78.0.3904.97-2.buster1_amd64.deb]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium-shell_78.0.3904.97-2.buster1_amd64.deb
+md5 = 0b410b2fe350d6018bcddf8cc53d39a7
+sha1 = 6b42cabc04bb646bb1730521fce7af5d80b81ffd
+sha256 = cf9b4075088447be16e88faeeae3903afff4ed17ecadaee941da4680b9892cdc
+
+[ungoogled-chromium_78.0.3904.97-2.buster1_amd64.buildinfo]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium_78.0.3904.97-2.buster1_amd64.buildinfo
+md5 = 94b70a0af59dbff3bedb2b6ffabd1473
+sha1 = 77b2ae89af8924cbaae8bab16479c4402253ba13
+sha256 = 8a1fb97956e61c7c286182ec8b3f5bf3ad554d74ff95d669cf7933d9cf487a40
+
+[ungoogled-chromium_78.0.3904.97-2.buster1_amd64.changes]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium_78.0.3904.97-2.buster1_amd64.changes
+md5 = 42a3a234ab4a9ab5dbd26f43ee5ca882
+sha1 = b812b4cdde657c7d13f0ca4880aede88a23ce92a
+sha256 = d000dd7e748460cc56e1e7d5f29ee6ad9d2ea7b882eb57d91a95fda9ba6eb6b5
+
+[ungoogled-chromium_78.0.3904.97-2.buster1_amd64.deb]
+url = https://github.com/tangalbert919/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2/ungoogled-chromium_78.0.3904.97-2.buster1_amd64.deb
+md5 = f82868a9a0f5f7ecf8d60f100949cf8f
+sha1 = 80b0a14834c57ca75e72de6d40bba1ae18668b3e
+sha256 = 208348b14efeea36c3c75a81e18b03e451dd0cbb1b0ed810d1f5fdee7fd5029a


### PR DESCRIPTION
This was built with the latest changes in `debian_buster` (except without commit `94a07d5eae92df9b25fa1c22a732557d703ba11e`, so I had to apply the `safebrowsing.patch` manually to finish the build).