### PR TITLE
Add 78.0.3904.97-2.disco1 for Ubuntu 19.04 (disco) amd64

### DIFF
--- a/config/platforms/ubuntu/disco_amd64/78.0.3904.97-2.disco1.ini
+++ b/config/platforms/ubuntu/disco_amd64/78.0.3904.97-2.disco1.ini
@@ -1,0 +1,77 @@
+[_metadata]
+status = development
+publication_time = 2019-11-13T13:41:48.812158
+github_author = riyad
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-common_78.0.3904.97-2.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-common_78.0.3904.97-2.disco1_amd64.deb
+md5 = 435e90bcbf6f58f14a1f2a634f2453a1
+sha1 = 107edb721ab5682b211933048b9a0a477b54a7ec
+sha256 = 44a361a66cbe412ffce79747afd08ea36a31dfb820dd3912d02801ad91775fb8
+
+[ungoogled-chromium-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb
+md5 = 86bca685e72a13fc50cd129aea78fdee
+sha1 = 5b8e4d05782b2c2930ddd5c5283638d493298658
+sha256 = 26af2de8349a38833dc8a240d284652f452c30a977953a45be1a836f59fd1c3b
+
+[ungoogled-chromium-driver-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-driver-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb
+md5 = e26ca7f40855a00988015bf24bb640a0
+sha1 = 7a13c62dd3686570645661b85445954333bd0a6a
+sha256 = 823f52d3080f04f1cb11b86071cb9fe0341dd2de72a6dcc2f1bb06c925fb1a93
+
+[ungoogled-chromium-driver_78.0.3904.97-2.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-driver_78.0.3904.97-2.disco1_amd64.deb
+md5 = 9a569478e36325e47ab827a55de950d4
+sha1 = 85eb72ead02ca78c3a179bde24fa07d8f3aaaf55
+sha256 = ca935753ae59a4b9fc76493071ece42e07818557eb56961c74f7516e3359fcb5
+
+[ungoogled-chromium-l10n_78.0.3904.97-2.disco1_all.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-l10n_78.0.3904.97-2.disco1_all.deb
+md5 = d597d29dcd8f53f10ecf853f795f11b9
+sha1 = 3dd21ea0b9c1337e1481635b873bcc319ae1a345
+sha256 = 8065cfd52dcd007a2c24c542bc7d4e78ab28f29f6928766e491f8f475dbd5e4b
+
+[ungoogled-chromium-sandbox-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-sandbox-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb
+md5 = de7b288e11871003b510802bea61cae1
+sha1 = 9722557ab78a69b0becbe2ed1c72a206400d6381
+sha256 = 1d0de52590b1b676fc83c36ceac997fd55825d29ff2bde9a2e58848ff2795790
+
+[ungoogled-chromium-sandbox_78.0.3904.97-2.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-sandbox_78.0.3904.97-2.disco1_amd64.deb
+md5 = 5daa03fad804283483c924d6a6536115
+sha1 = b7de8dcbde05b4a4663de303db2019190cfbc999
+sha256 = 62f045dfeb204da080734564a44e1d4676480fb54bfca59e3e0d980eddeaf236
+
+[ungoogled-chromium-shell-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-shell-dbgsym_78.0.3904.97-2.disco1_amd64.ddeb
+md5 = a82ea0c200c4aa8c7da7f22b7e3528ed
+sha1 = 2860edc8421bd3a160443a7877f1a004fd89ef82
+sha256 = c03fdb2aabd0d1372529ff01ee4ebe8f0e878d2849928c81c52d2b5492845718
+
+[ungoogled-chromium-shell_78.0.3904.97-2.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium-shell_78.0.3904.97-2.disco1_amd64.deb
+md5 = 1ebad7004e680da457ffd3d3433a3b5f
+sha1 = 6d5e2672bf5a6d66f9fe282ca0ac85500955d85c
+sha256 = f6a9cdc0882222b8032279a09d9c1ae2597b1fdfebff4125b9fbb12ffe1b0a22
+
+[ungoogled-chromium_78.0.3904.97-2.disco1_amd64.buildinfo]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium_78.0.3904.97-2.disco1_amd64.buildinfo
+md5 = 839d21fd988f427913c05e16c5481a63
+sha1 = c64fa3fe6deb99f8553f991aecb5cb2eb1935290
+sha256 = 55522e4d5465bd1306aca4a997039e73b13ca0eec20330ebdf6943e57a1d8a44
+
+[ungoogled-chromium_78.0.3904.97-2.disco1_amd64.changes]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium_78.0.3904.97-2.disco1_amd64.changes
+md5 = 2305e1c60ea01250e39a602ea04dfe6e
+sha1 = 1d06a4f3d490b9984b4f216170e20116a2b3fb5b
+sha256 = b4a2f5adb0c69b4832b0b90f3407e1cc48228067cc6a39ef8d52454bcfbc5907
+
+[ungoogled-chromium_78.0.3904.97-2.disco1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/78.0.3904.97-2.disco1/ungoogled-chromium_78.0.3904.97-2.disco1_amd64.deb
+md5 = b92b4905c820a6621089b5fb0ee0ca49
+sha1 = 7b120e983c58c1fd252070308b840ae28d66d24a
+sha256 = f0d71ee97163d96eb7048dfb64d99152b4b222c766f15ac33a956ddf7cc8a426


### PR DESCRIPTION
Based on https://github.com/ungoogled-software/ungoogled-chromium-debian/pull/28