### PR TITLE
Add 79.0.3945.130-1 for macOS

### DIFF
--- a/config/platforms/macos/79.0.3945.130-1.ini
+++ b/config/platforms/macos/79.0.3945.130-1.ini
@@ -1,0 +1,11 @@
+[_metadata]
+status = development
+publication_time = 2020-01-17T18:01:14.991131
+github_author = kramred
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_79.0.3945.130-1.1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-binaries/releases/download/79.0.3945.130-1/ungoogled-chromium_79.0.3945.130-1.1_macos.dmg
+md5 = d8b7fa366a3d96a392b937b39aedf5a6
+sha1 = be7a3c40f80215911806c7f57e95286669fc8ab3
+sha256 = 2ca7ecba09007b23c42e6b3fdf51930738c024b73c3427edb6945f257c67b883


### PR DESCRIPTION
I used https://github.com/Zoraver/ungoogled-chromium repo at the stage of the [PR#910](https://github.com/Eloston/ungoogled-chromium/pull/910), no changes were necessary for the macOS specifics