### PR TITLE
Add 80.0.3987.149-2.eoan1 for Ubuntu 19.10 (eoan) amd64

### DIFF
--- a/config/platforms/ubuntu/eoan_amd64/80.0.3987.149-2.eoan1.ini
+++ b/config/platforms/ubuntu/eoan_amd64/80.0.3987.149-2.eoan1.ini
@@ -1,0 +1,76 @@
+[_metadata]
+publication_time = 2020-04-02T08:39:19.774538
+github_author = riyad
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-common_80.0.3987.149-2.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-common_80.0.3987.149-2.eoan1_amd64.deb
+md5 = 9d441f039f3f48ee94d1c229947b52f3
+sha1 = 9d387c5d52ac4db3ea1764a71381e629efa29fdb
+sha256 = e0d3471113e9d90daadc7f2ca916bfdbfb1998ea8c0a351dad22e707032d42c7
+
+[ungoogled-chromium-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb
+md5 = c3a29fb25e86235230c1e17c6151676d
+sha1 = e66b6cc79efd68c1a1ac42d4055ae193eab3a008
+sha256 = 93b908e99165869cd50e0cc4562823ee163df6d48269fa90885acfbeb2929a37
+
+[ungoogled-chromium-driver-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-driver-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb
+md5 = 397731c6894e548d5f7e8dad9bd23f71
+sha1 = 69d5b9322d756305334b41aa2aa1cc7f56a550de
+sha256 = 3b25ddde7cd3e2ba22962bccfc6adf250f8271925fcb07c8a0620df9b8874bf1
+
+[ungoogled-chromium-driver_80.0.3987.149-2.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-driver_80.0.3987.149-2.eoan1_amd64.deb
+md5 = 5ecd8e0e76885bf8437f1bfa2765bff9
+sha1 = 140cf3d00f7cd8d652c5f5e84a2bc0829ae6e809
+sha256 = 5c9b7e7e37069cf19a5c1241e80825fd95df6ace1de3d99b61c8f66fd38bd7b0
+
+[ungoogled-chromium-l10n_80.0.3987.149-2.eoan1_all.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-l10n_80.0.3987.149-2.eoan1_all.deb
+md5 = 8a41b21cfae50e4fd6680404c312fa05
+sha1 = aee0f06f8f303aa797e8dba11526dc5446fcfe59
+sha256 = f71f356a919a2d6631285e642caa2a70b9083cffbf8e3b68ca3ba373a7aaed0d
+
+[ungoogled-chromium-sandbox-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-sandbox-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb
+md5 = d569330c91bda93d5580c4d06fe17ca6
+sha1 = 09b7abf776a67414c5724d6a74f98ead78b0f3f1
+sha256 = 8688ba89c314ef7d9718cc74867e4bf279caeeae642681ea9ca0626efbba2ef1
+
+[ungoogled-chromium-sandbox_80.0.3987.149-2.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-sandbox_80.0.3987.149-2.eoan1_amd64.deb
+md5 = e7f6aaffaa3d79a5ac98c39ea555d25b
+sha1 = 4f71b4b4b87fb965582a199ee7d87346be54ffdc
+sha256 = 9914ae2d31935c442be17daca703ab52b02816b7a4d7b33f2db7b128a84f9246
+
+[ungoogled-chromium-shell-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-shell-dbgsym_80.0.3987.149-2.eoan1_amd64.ddeb
+md5 = abbb2b044f354ddf8220eed0022b09a1
+sha1 = a1d46de9547d6b74392cc1cbc9d448f9e05bc7e5
+sha256 = a047b8c52aed3bd16a931675762931dafeee98220eeddbc837a8294b628b3d6d
+
+[ungoogled-chromium-shell_80.0.3987.149-2.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium-shell_80.0.3987.149-2.eoan1_amd64.deb
+md5 = e68134f1c00d3a136e606b937cbc699c
+sha1 = b75905c9506b965643c87f90cce4498d37406f69
+sha256 = 7e352080af21ec067b9d640d438ed1d7a4be737688b1b22c0bcedab0451fdc0b
+
+[ungoogled-chromium_80.0.3987.149-2.eoan1_amd64.buildinfo]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium_80.0.3987.149-2.eoan1_amd64.buildinfo
+md5 = 435969c40f7022c632850a048747205b
+sha1 = dc465f016020aa0c804eb1de8ea7ba146b5db7db
+sha256 = 6812e58fef89a180f560f0968360dcebe0f031eec185d2973f48760158c08233
+
+[ungoogled-chromium_80.0.3987.149-2.eoan1_amd64.changes]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium_80.0.3987.149-2.eoan1_amd64.changes
+md5 = 262be619bae712736ebf4cc74d9b659e
+sha1 = 6fcddab6e07b251f801bb1046821462d838200ba
+sha256 = 5aa3269ad784383de9a055ebde94ac200643e41b7cba7dba7d63449fcf8e6818
+
+[ungoogled-chromium_80.0.3987.149-2.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.149-2.eoan1/ungoogled-chromium_80.0.3987.149-2.eoan1_amd64.deb
+md5 = 06987f1d4f83f0c04d5c91bc36d7e80f
+sha1 = 4c07842b2a020eb960824f6b8b9cd16a6e632f72
+sha256 = 2d4a299ceec3cd4f0d2de16b76505585ba6c0c5c123b9998c86c52515b3d1587


### PR DESCRIPTION
Based on https://github.com/ungoogled-software/ungoogled-chromium-debian/releases/tag/80.0.3987.149-2.eoan1