### PR TITLE
Add 80.0.3987.162-1.eoan1 for Ubuntu 19.10 (eoan) amd64

### DIFF
--- a/config/platforms/ubuntu/eoan_amd64/80.0.3987.162-1.eoan1.ini
+++ b/config/platforms/ubuntu/eoan_amd64/80.0.3987.162-1.eoan1.ini
@@ -1,0 +1,76 @@
+[_metadata]
+publication_time = 2020-04-03T08:04:56.576924
+github_author = riyad
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-common_80.0.3987.162-1.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-common_80.0.3987.162-1.eoan1_amd64.deb
+md5 = bb3f21f86895cc32653045c76291e5c9
+sha1 = dd545d9bee66826468558c608692eb73090c6d47
+sha256 = 16b58ed1df34a72fbf50656f4c2aed50aad916851014e8b7d823cf633f502ce9
+
+[ungoogled-chromium-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb
+md5 = 32fbb835d11b5c391664c29e138a3241
+sha1 = c2f540deda6510769b1f348a8d1c473ed4391e84
+sha256 = 5de51c2d68c6d9363baeddbf64ef07ac7573d3b871eee8ac97889480a4c96637
+
+[ungoogled-chromium-driver-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-driver-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb
+md5 = 8e61f1f32c871c80ffa2c5c87fc3cc4d
+sha1 = 6690ba8ddcf6c9428f95e713bbc7b0901182fe57
+sha256 = 06d8a5774f990d9717b3c895b84500da5c66a35e0eaff30fb28f7d0b6ac03b1a
+
+[ungoogled-chromium-driver_80.0.3987.162-1.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-driver_80.0.3987.162-1.eoan1_amd64.deb
+md5 = 7eea34bfefd045f21c0ce979caf3e56f
+sha1 = a35efa0869a13cc8d480352a667681374a48293f
+sha256 = 970707a16eabf45d992fa9d8777b242f43899e5fb4257b7f950d66581c787b6b
+
+[ungoogled-chromium-l10n_80.0.3987.162-1.eoan1_all.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-l10n_80.0.3987.162-1.eoan1_all.deb
+md5 = 56ed9dc6b72f3ab145ab4da1e17af484
+sha1 = 6f72ce23bfdf9679d778abe825e717d884e52867
+sha256 = 318b8ac645134a6357322de69c888b0b390b6020f506a54366a2cc05783e41d3
+
+[ungoogled-chromium-sandbox-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-sandbox-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb
+md5 = 45dfe3c218a4378b7a4237cc31b29b96
+sha1 = 41cf83addfd50b30b88e209299c02ef180204708
+sha256 = a00ff013b0cb389bdcd71b5118eb44fb7321db7ba36ed006359f20ba3655f9ca
+
+[ungoogled-chromium-sandbox_80.0.3987.162-1.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-sandbox_80.0.3987.162-1.eoan1_amd64.deb
+md5 = bf5b9f4eead179a70c0cecdab4a0bd2f
+sha1 = 92b86b92fa144ff99fec2ea256f684dafe34f4fc
+sha256 = f2b6245b2913518f9de7c3a742ac428b2745e6377200554c93cc13758028b969
+
+[ungoogled-chromium-shell-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-shell-dbgsym_80.0.3987.162-1.eoan1_amd64.ddeb
+md5 = 0b92968e6a004545d4771e6ece25d59e
+sha1 = b7cb8bd13ab59846b89ef2eedfd6546daab3cdb4
+sha256 = 1fe6849253a2582f1c553d9eb51bf14a270c433315be30a6de28c38ac31e1821
+
+[ungoogled-chromium-shell_80.0.3987.162-1.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium-shell_80.0.3987.162-1.eoan1_amd64.deb
+md5 = 3f98686e0289f425ae674aac4d819be9
+sha1 = c623fa944aec3f8ffd97a2d65b0907c6f67c528c
+sha256 = 53c9db24142c318358973e663121ddbbe6155bc4a75e1298528ca265480e4611
+
+[ungoogled-chromium_80.0.3987.162-1.eoan1_amd64.buildinfo]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium_80.0.3987.162-1.eoan1_amd64.buildinfo
+md5 = 73313439f8aefc36335cc58703fed2c8
+sha1 = 36ac04bd0747b51128a05e47f2de68e27f6de500
+sha256 = 5d6dbf482abc503f3b8300baba13f56843cda6f551fa47e21ba5c6d4d2243623
+
+[ungoogled-chromium_80.0.3987.162-1.eoan1_amd64.changes]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium_80.0.3987.162-1.eoan1_amd64.changes
+md5 = b8626237ea14af143042f3afd7d6d56e
+sha1 = 50f94db8e8c1a25b16748e1fb78dca4135a6851e
+sha256 = a2727db9fe26f09efc603537ebf35e92e9c303c80fecbe4a7bf2f962334fd4b3
+
+[ungoogled-chromium_80.0.3987.162-1.eoan1_amd64.deb]
+url = https://github.com/riyad/ungoogled-chromium-binaries/releases/download/80.0.3987.162-1.eoan1/ungoogled-chromium_80.0.3987.162-1.eoan1_amd64.deb
+md5 = ec44beb291886869970c005036dc9264
+sha1 = a37ea6e80c8f0962d766cf48d21f8f7a51e3e966
+sha256 = 3a2034b659f7cee3c66f04b7b01318f292ae83eff151e1dfaa2822b61f6ca4fb


### PR DESCRIPTION
Based on https://github.com/ungoogled-software/ungoogled-chromium-debian/releases/tag/80.0.3987.162-1.eoan1

Replaces #152