### PR TITLE
Add 81.0.4044.113-1 for macOS

### DIFF
--- a/config/platforms/macos/81.0.4044.113-1.ini
+++ b/config/platforms/macos/81.0.4044.113-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-04-18T16:11:37.195345
+github_author = kramred
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_81.0.4044.113-1.1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-binaries/releases/download/81.0.4044.113-1/ungoogled-chromium_81.0.4044.113-1.1_macos.dmg
+md5 = 1896dd601245287d1b36b245e8a02321
+sha1 = 39c2a054af0a1193f8b190a409e31c2328b4a9e6
+sha256 = ea4642e72e390038e471cd5f055b397077ac677c47e6729d99000e05d0a6dcce


### PR DESCRIPTION
Based on [PR 1003](https://github.com/Eloston/ungoogled-chromium/pull/1003) – no changes to macOS patches were necessary