### PR TITLE
Add 81.0.4044.122-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/81.0.4044.113-1.ini
+++ b/config/platforms/archlinux/81.0.4044.113-1.ini
@@ -1,7 +1,7 @@
 [_metadata]
 publication_time = 2020-04-23T23:11:25.481734
 github_author = zocker-160
-# Add a `note` field here for additional information. Markdown is supported
+note = VAAPI seems to be broken on Intel and AMD GPUs
 
 [ungoogled-chromium-81.0.4044.113-1-x86_64.pkg.tar.xz]
 url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/81.0.4044.113-1/ungoogled-chromium-81.0.4044.113-1-x86_64.pkg.tar.xz

--- a/config/platforms/archlinux/81.0.4044.122-1.ini
+++ b/config/platforms/archlinux/81.0.4044.122-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-04-29T22:30:36.550083
+github_author = zocker-160
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-81.0.4044.122-1-x86_64.pkg.tar.xz]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/81.0.4044.122-1/ungoogled-chromium-81.0.4044.122-1-x86_64.pkg.tar.xz
+md5 = 3960b055b79b6393dc65779e60b8b606
+sha1 = 231680de239c3e3b90a1e1527675a7c37c085de8
+sha256 = 7ffbdd45b00249c26c1e8674aa6aa0d73c7c8c31c88622d87afc51ef587ed54f


### PR DESCRIPTION
I also added a note to the 113-1 release, because there are reports of problems with VAAPI on Intel and AMD GPUs

the sha256 of the 113 release did **not** change, but a new line character got added for some reason