### PR TITLE
Add 81.0.4044.138-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/81.0.4044.138-1.ini
+++ b/config/platforms/archlinux/81.0.4044.138-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-05-12T02:50:27.796154
+github_author = Myl0g
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-81.0.4044.138-1-x86_64.pkg.tar.xz]
+url = https://github.com/Myl0g/ungoogled-chromium-binaries/releases/download/81.0.4044.138-1/ungoogled-chromium-81.0.4044.138-1-x86_64.pkg.tar.xz
+md5 = cbc2c3fb9876f6546b263bb20d7c7bf8
+sha1 = a6042fff890107dcb4917dc2e6ae16214afae2cf
+sha256 = 329ee3379684e8df9d4a960def6b91ae9b640b82e956b6878286c71900cae08d


### PR DESCRIPTION
Newly created from the latest commit (3843e05) in ungoogled-software/ungoogled-chromium-archlinux.