### PR TITLE
Add 84.0.4147.89-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/84.0.4147.89-1.ini
+++ b/config/platforms/archlinux/84.0.4147.89-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-07-18T13:28:01.974504
+github_author = Myl0g
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-84.0.4147.89-1-x86_64.pkg.tar.zst]
+url = https://github.com/Myl0g/ungoogled-chromium-binaries/releases/download/84.0.4147.89-1/ungoogled-chromium-84.0.4147.89-1-x86_64.pkg.tar.zst
+md5 = d57fa4997ca97ed2467320e2525f8222
+sha1 = 9a23b609e5f07bf323ccc6a12409a6cc070bffb1
+sha256 = c531c28f9e0be9ea2826db9746b9dc7c81a38792c832139153265994afdee909


### PR DESCRIPTION
Created from commit 8b1c8b69e3743e2eec2f050bfd693bb02daaa759 on https://github.com/jstkdng/ungoogled-chromium-archlinux - some changes were made since I built the binary but the changes only affected the README (which I figure isn't critical to the build).