### PR TITLE
Add 84.0.4147.89-1 for macOS

### DIFF
--- a/config/platforms/macos/84.0.4147.89-1.2.ini
+++ b/config/platforms/macos/84.0.4147.89-1.2.ini
@@ -1,5 +1,5 @@
 [_metadata]
-publication_time = 2020-07-21T01:11:03
+publication_time = 2020-07-21T01:11:03.123456
 github_author = kramred
 note = Manually added release, which was fully built using GitHub Actions, see [here](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/84.0.4147.89-1.2)
 

--- a/config/platforms/macos/84.0.4147.89-1.2.ini
+++ b/config/platforms/macos/84.0.4147.89-1.2.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-07-21T01:11:03
+github_author = kramred
+note = Manually added release, which was fully built using GitHub Actions, see [here](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/84.0.4147.89-1.2)
+
+[ungoogled-chromium_84.0.4147.89-1.2_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-macos/releases/download/84.0.4147.89-1.2/ungoogled-chromium_84.0.4147.89-1.2_macos.dmg
+md5 = f6eca855be5bb90254f1a1d241b12e67
+sha1 = c41bd52829748d84feab653260eb80e9b4437bfb
+sha256 = b73ca8690fd372730720066711aab24e8396974291eb406c3fffb094772c8402

--- a/config/platforms/macos/84.0.4147.89-1.ini
+++ b/config/platforms/macos/84.0.4147.89-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-07-21T13:00:17.417090
+github_author = kramred
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_84.0.4147.89-1.1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-binaries/releases/download/84.0.4147.89-1/ungoogled-chromium_84.0.4147.89-1.1_macos.dmg
+md5 = d2178d0130699f31420252f08c21958d
+sha1 = a8ae68fcd9c35889c491c8d73c21a08bb5e23b85
+sha256 = af81afc0f82d19eb77496bf3ca0f9db4091c17119b8d28f2b34d44c33029f24f


### PR DESCRIPTION
There is now also a build and release done fully automatically on GitHub Actions.
See release [here](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/84.0.4147.89-1.2) - based on the same source code as this one with the GitHub Actions Workflow from this [PR#54](https://github.com/ungoogled-software/ungoogled-chromium-macos/pull/54)
Maybe I'll create a new ini manually for now, to point to that release.