### PR TITLE
Add 84.0.4147.105-1.1 for macOS (GitHub Actions build/release)

### DIFF
--- a/config/platforms/macos/84.0.4147.105-1.1.ini
+++ b/config/platforms/macos/84.0.4147.105-1.1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-07-29T12:37:03.123456
+github_author = kramred
+note = Manually added release, which was fully built using GitHub Actions, see [here](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/84.0.4147.105-1.1)
+
+[ungoogled-chromium_84.0.4147.105-1.1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-macos/releases/download/84.0.4147.105-1.1/ungoogled-chromium_84.0.4147.105-1.1_macos.dmg
+md5 = c0b1f5c226f6f9e44da450c88af4ee72
+sha1 = ae4d2adc7b663a49b4caedc5418fddd651473bdf
+sha256 = d660a6bf52a4513a4e8fd2d338a13000ebb704698e0a6c438c585269ed9bbb8f


### PR DESCRIPTION
Manually added the current release built with GitHub Actions – this should probably be automated in the future…