### PR TITLE
Add 85.0.4183.83-1.1 for macOS (GitHub Actions build/release)

### DIFF
--- a/config/platforms/macos/85.0.4183.83-1.1.ini
+++ b/config/platforms/macos/85.0.4183.83-1.1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-09-02T12:05:38.123456
+github_author = kramred
+note = Manually added release, which was fully built using GitHub Actions, see [here](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/85.0.4183.83-1.1)
+
+[ungoogled-chromium_85.0.4183.83-1.1_macos.dmg]
+url = https://github.com/kramred/ungoogled-chromium-macos/releases/download/85.0.4183.83-1.1/ungoogled-chromium_85.0.4183.83-1.1_macos.dmg
+md5 = 007f6466679e4e504e4c6eccc686a14a
+sha1 = 84308fe072d3e7d66ae2d736ae8c3af8e01f9849
+sha256 = 34947afb19d11e56eacd9f4e7b9400bdb3cfc65c5712b05e66b4b4d2cc610b2c


### PR DESCRIPTION
Based on [PR#57](https://github.com/ungoogled-software/ungoogled-chromium-macos/pull/57) from @Zoraver, built using [GitHub Actions](https://github.com/kramred/ungoogled-chromium-macos/releases/tag/85.0.4183.83-1.1)
