### PR TITLE
Add 84.0.4147.135-1.musl1 for Portable Linux 64-bit (for musl libc)

### DIFF
--- a/config/platforms/linux_portable/64bit_musl/84.0.4147.135-1.musl1.ini
+++ b/config/platforms/linux_portable/64bit_musl/84.0.4147.135-1.musl1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-09-03T03:32:20.667265
+github_author = Cubified
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_84.0.4147.135-1.musl1_linux.tar.xz]
+url = https://github.com/Cubified/ungoogled-chromium-binaries/releases/download/84.0.4147.135-1.musl1/ungoogled-chromium_84.0.4147.135-1.musl1_linux.tar.xz
+md5 = 52b2e7dcf0dae42357f6ba4dab9ffe70
+sha1 = bc15bf1e1b2893599f5615bb798447e9bfc1c9ba
+sha256 = f2f503bc38ca670a898ae4a736cf972a0c3fbfb2d3205d7c76c9478355bde7b0


### PR DESCRIPTION
Based on [PR#61](https://github.com/ungoogled-software/ungoogled-chromium-portablelinux/pull/61).