### PR TITLE
Add 87.0.4280.88-1.1 for Portable Linux 64-bit

### DIFF
--- a/config/platforms/linux_portable/64bit/87.0.4280.88-1.1.ini
+++ b/config/platforms/linux_portable/64bit/87.0.4280.88-1.1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2020-12-07T05:18:04.779045
+github_author = mcstrugs
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_87.0.4280.88-1.1_linux.tar.xz]
+url = https://github.com/mcstrugs/ungoogled-chromium-binaries/releases/download/87.0.4280.88-1.1/ungoogled-chromium_87.0.4280.88-1.1_linux.tar.xz
+md5 = 420fc1e570e578bfcb0a94d16fcf7933
+sha1 = b1a781226d0c60164ce240411d4c15fb47224644
+sha256 = 76604aff59111b3cdfc2c84c00909fcf78fa77115bfe80a4075bba2c40aac446


### PR DESCRIPTION
I should have bundled this with the AppImage release that I did. This builds as a prereq to the AppImage and I didn't notice I had a newer version. 