### PR TITLE
Add 88.0.4324.150-musl for Portable Linux 64-bit (for musl libc)

### DIFF
--- a/config/platforms/linux_portable/64bit_musl/87.0.4280.141-musl.ini
+++ b/config/platforms/linux_portable/64bit_musl/87.0.4280.141-musl.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-01-17T09:07:25.229545
+github_author = git-bruh
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_87.0.4280.141-1.musl.tar.xz]
+url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/87.0.4280.141-musl/ungoogled-chromium_87.0.4280.141-1.musl.tar.xz
+md5 = 4046869347a89f4b0a0ac4cbe35baffd
+sha1 = 1e5166d4bbf212f5107073f6ca94a1043b50054c
+sha256 = 18fbf56054fe888dc9407b0d50a8627fd889d6bfda56bdde6ae731acbf347428

--- a/config/platforms/linux_portable/64bit_musl/87.0.4280.141-musl.ini
+++ b/config/platforms/linux_portable/64bit_musl/87.0.4280.141-musl.ini
@@ -1,7 +1,7 @@
 [_metadata]
 publication_time = 2021-01-17T09:07:25.229545
 github_author = git-bruh
-# Add a `note` field here for additional information. Markdown is supported
+note = `rm -rf` the `var` directory in the archive
 
 [ungoogled-chromium_87.0.4280.141-1.musl.tar.xz]
 url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/87.0.4280.141-musl/ungoogled-chromium_87.0.4280.141-1.musl.tar.xz

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.150-musl.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.150-musl.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-02-10T13:02:39.307018
+github_author = git-bruh
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_88.0.4324.150.musl.tar.xz]
+url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.150-musl/ungoogled-chromium_88.0.4324.150.musl.tar.xz
+md5 = 796a4f57eed20eeb6c67ed60c9869301
+sha1 = d4b6f6f87aa2d7d64c0b2d86094e7d70e0d787fc
+sha256 = 1caabf1ad43b8333347c48c5b55f7f71332a5b65e3f067d31134b8564c45fee6

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.150-musl.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.150-musl.ini
@@ -1,7 +1,7 @@
 [_metadata]
 publication_time = 2021-02-10T13:02:39.307018
 github_author = git-bruh
-# Add a `note` field here for additional information. Markdown is supported
+note = This binary is built without the SETUID sandbox (a kernel with user namespaces support is required without this sandbox) and does NOT support `cups`, `dbus`, `pulseaudio`, `vaapi`, `wayland` and `widewine`. System libraries are required for `ffmpeg`, `flac`, `libdrm`, and `opus`. `rm -rf` the `var/` directory.
 
 [ungoogled-chromium_88.0.4324.150.musl.tar.xz]
 url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.150-musl/ungoogled-chromium_88.0.4324.150.musl.tar.xz

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
@@ -1,9 +1,7 @@
 [_metadata]
 publication_time = 2021-02-07T16:04:08.384237
 github_author = git-bruh
-note = "This binary is built without support for `cups`, `dbus`, `pulseaudio`, `vaapi`, `wayland` and `widewine`.
-System libraries are required for `ffmpeg`, `flac`, `icu`, `libdrm`, `libevent` and `opus`. Most of these are probably pulled in already as dependencies for other packages. 
-`rm -rf` the `var/` directory."
+note = This binary is built without support for `cups`, `dbus`, `pulseaudio`, `vaapi`, `wayland` and `widewine`. System libraries are required for `ffmpeg`, `flac`, `icu`, `libdrm`, `libevent` and `opus`. Most of these are probably pulled in already as dependencies for other packages. `rm -rf` the `var/` directory.
 
 [ungoogled-chromium_88.0.4324.150.musl.tar.xz]
 url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.150/ungoogled-chromium_88.0.4324.150.musl.tar.xz

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-02-07T16:04:08.384237
+github_author = git-bruh
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_88.0.4324.150.musl.tar.xz]
+url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.150/ungoogled-chromium_88.0.4324.150.musl.tar.xz
+md5 = b43b9b94fd329c00662017b6caf44801
+sha1 = 4f42fc431fb19ada07f410d85357b2e206c3a8b2
+sha256 = e0bf59af95b23282d43d9d71725f6274a0f3dfc2d645d778f2e7b3940f66ecfe

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
@@ -1,7 +1,9 @@
 [_metadata]
 publication_time = 2021-02-07T16:04:08.384237
 github_author = git-bruh
-# Add a `note` field here for additional information. Markdown is supported
+note = This binary is built without support for `cups`, `dbus`, `pulseaudio`, `vaapi`, `wayland` and `widewine`.
+System libraries are required for `ffmpeg`, `flac`, `icu`, `libdrm`, `libevent` and `opus`. Most of these are probably pulled in already as dependencies for other packages. 
+`rm -rf` the `var/` directory.
 
 [ungoogled-chromium_88.0.4324.150.musl.tar.xz]
 url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.150/ungoogled-chromium_88.0.4324.150.musl.tar.xz

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.150.ini
@@ -1,9 +1,9 @@
 [_metadata]
 publication_time = 2021-02-07T16:04:08.384237
 github_author = git-bruh
-note = This binary is built without support for `cups`, `dbus`, `pulseaudio`, `vaapi`, `wayland` and `widewine`.
+note = "This binary is built without support for `cups`, `dbus`, `pulseaudio`, `vaapi`, `wayland` and `widewine`.
 System libraries are required for `ffmpeg`, `flac`, `icu`, `libdrm`, `libevent` and `opus`. Most of these are probably pulled in already as dependencies for other packages. 
-`rm -rf` the `var/` directory.
+`rm -rf` the `var/` directory."
 
 [ungoogled-chromium_88.0.4324.150.musl.tar.xz]
 url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.150/ungoogled-chromium_88.0.4324.150.musl.tar.xz

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.96-musl.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.96-musl.ini
@@ -1,7 +1,7 @@
 [_metadata]
 publication_time = 2021-01-22T05:14:36.445674
 github_author = git-bruh
-# Add a `note` field here for additional information. Markdown is supported
+note = `rm -rf` the `var` directory in the archive
 
 [chromium@88.0.4324.96-1.tar.xz]
 url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.96-musl/chromium@88.0.4324.96-1.tar.xz

--- a/config/platforms/linux_portable/64bit_musl/88.0.4324.96-musl.ini
+++ b/config/platforms/linux_portable/64bit_musl/88.0.4324.96-musl.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-01-22T05:14:36.445674
+github_author = git-bruh
+# Add a `note` field here for additional information. Markdown is supported
+
+[chromium@88.0.4324.96-1.tar.xz]
+url = https://github.com/git-bruh/ungoogled-chromium-binaries/releases/download/88.0.4324.96-musl/chromium@88.0.4324.96-1.tar.xz
+md5 = 0a2ecb88625bb530225698176996a5ac
+sha1 = 41cb5f93518c96c5acffdd5863600f86ff4a7420
+sha256 = 03375fbfba5308c6a5b8902fd4449475fce8937cad57a19f6ee9adaf70f30cfa


### PR DESCRIPTION
https://github.com/ungoogled-software/ungoogled-chromium-portablelinux/pull/84

Built with [this](https://github.com/kiss-community/repo-community/blob/main/community/chromium/build) script