### PR TITLE
Add Manjaro as new platform + 88.0.4324.182-1 and 89.0.4389.82-2 for Manjaro

### DIFF
--- a/config/platforms/manjaro/88.0.4324.182-1.ini
+++ b/config/platforms/manjaro/88.0.4324.182-1.ini
@@ -1,0 +1,16 @@
+[_metadata]
+publication_time = 2021-03-12T20:13:49.410871
+github_author = zocker-160
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-88.0.4324.182-1-build-Manjaro.log]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/88.0.4324.182-1/ungoogled-chromium-88.0.4324.182-1-build-Manjaro.log
+md5 = c398fcf611e6e2cebfdf59d7eec0dc9d
+sha1 = ef50f7845c92c582ae78b766d4f91c1c14ff342c
+sha256 = 8882822f12f66aa5e74271ca9bb4a1be51602449e0845988d112297f644d0145
+
+[ungoogled-chromium-88.0.4324.182-1-x86_64-Manjaro.pkg.tar.zst]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/88.0.4324.182-1/ungoogled-chromium-88.0.4324.182-1-x86_64-Manjaro.pkg.tar.zst
+md5 = ce5d39cc20ab65e1decde53ad2a421b0
+sha1 = 0ffc7de54b7825ac43384ae34f2e938f5fde2b53
+sha256 = b9108ee44a60fc9dc62cd8fa1f132e58c53dfbdf7c4466a5efa00574f8bec532

--- a/config/platforms/manjaro/89.0.4389.82-2.ini
+++ b/config/platforms/manjaro/89.0.4389.82-2.ini
@@ -1,0 +1,16 @@
+[_metadata]
+publication_time = 2021-03-13T17:48:40.693806
+github_author = zocker-160
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-89.0.4389.82-2-Manjaro-build.log]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/89.0.4389.82-2/ungoogled-chromium-89.0.4389.82-2-Manjaro-build.log
+md5 = a1aaa2eb53d8049b3fd953ca405f4b2b
+sha1 = 98e095230bf084add8cb47b1cd0c0bfec3e4c51a
+sha256 = 92845ecd643d497e8515e9a88daae6748087a3ecd1c7b67c62b3b4e02e6f448e
+
+[ungoogled-chromium-89.0.4389.82-2-Manjaro-x86_64.pkg.tar.zst]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/89.0.4389.82-2/ungoogled-chromium-89.0.4389.82-2-Manjaro-x86_64.pkg.tar.zst
+md5 = 659d92055625b5d6bd910b228287d479
+sha1 = 1df519d23434b9a070d635874456b71d87fea307
+sha256 = 0f103a2ba1be4908146829cba4c18d1d25c13e01d64b852ff6bf53f48c60e914

--- a/config/platforms/manjaro/display_name
+++ b/config/platforms/manjaro/display_name
@@ -1,0 +1,1 @@
+Manjaro


### PR DESCRIPTION
I think this is necessary, because Manjaro updates slower than Arch, which very often leads to errors and broken dependencies when using the Arch builds.

For this package I am using the PKGBUILD from the [ungoogled-chromium-archlinux repo](https://github.com/ungoogled-software/ungoogled-chromium-archlinux), but compiled against the versions of the dependencies Manjaro provides.