### PR TITLE
Add Artix Linux as a Platform and Add 89.0.4389.114-1 for Artix Linux

### DIFF
--- a/config/platforms/artix/89.0.4389.114-1.ini
+++ b/config/platforms/artix/89.0.4389.114-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-04-02T05:21:38.247353
+github_author = ccxex29
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-89.0.4389.114-1-x86_64.pkg.tar.zst]
+url = https://github.com/ccxex29/ungoogled-chromium-binaries/releases/download/89.0.4389.114-1/ungoogled-chromium-89.0.4389.114-1-x86_64.pkg.tar.zst
+md5 = a9e891bf1bc3de00ba86a599bf7abe64
+sha1 = 49b5537764a42abdd74abab1b3e9760b7308d867
+sha256 = cad777dcdbd0ad0ed9a7f106e70520034dce07b639fb69c19144ec65d2ce44d2

--- a/config/platforms/artix/display_name
+++ b/config/platforms/artix/display_name
@@ -1,0 +1,1 @@
+Artix Linux


### PR DESCRIPTION
I think the packages for Arch Linux family are more or less the same. I tried both Arch Linux and Manjaro releases and both works fine.  

However, I think Artix Linux should also be separate from Arch Linux because the system environment is more different than Manjaro to Arch is and the version build information shown on About Chromium.  

Let me know what you think.