### PR TITLE
Add 89.0.4389.114-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/89.0.4389.114-1.ini
+++ b/config/platforms/archlinux/89.0.4389.114-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-04-04T21:43:48.366635
+github_author = 98WuG
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-89.0.4389.114-1-x86_64.pkg.tar.zst]
+url = https://github.com/98WuG/ungoogled-chromium-binaries/releases/download/89.0.4389.114-1/ungoogled-chromium-89.0.4389.114-1-x86_64.pkg.tar.zst
+md5 = b7ecc1ad831f184f8f9322f3906f87c9
+sha1 = e780cbfe4a3bb7e0cbb2be1fa4be96306d022344
+sha256 = 98d566f0e0a515bfce0a121e4bb340c4abc447c6dfea50b749d4931b6c719a47


### PR DESCRIPTION
Built in a clean chroot with `extra-x86_64-build` as described in https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot.