### PR TITLE
Add 89.0.4389.128-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/89.0.4389.128-1.ini
+++ b/config/platforms/archlinux/89.0.4389.128-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-04-20T17:10:52.513893
+github_author = 98WuG
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-89.0.4389.128-1-x86_64.pkg.tar.zst]
+url = https://github.com/98WuG/ungoogled-chromium-binaries/releases/download/89.0.4389.128-1/ungoogled-chromium-89.0.4389.128-1-x86_64.pkg.tar.zst
+md5 = 1cb4ad3d72f5f90b29cfe3c79c528a0d
+sha1 = fb33c974df13ebfbc9a57ae94fa9f237dc798015
+sha256 = ee1827d9ded822a72922db4a41f666a74d04f877cf3b55ae445fcaa7bd44a001


### PR DESCRIPTION
Built in a clean chroot with `extra-x86_64-build` as described in https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot.