### PR TITLE
Add 90.0.4430.85-1.1 for Linux AppImage 64-bit

### DIFF
--- a/config/platforms/appimage/64bit/90.0.4430.85-1.1.ini
+++ b/config/platforms/appimage/64bit/90.0.4430.85-1.1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-04-29T15:58:15.361937
+github_author = mdedonno1337
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled_chromium_90.0.4430.85-1.1.AppImage]
+url = https://github.com/mdedonno1337/ungoogled-chromium-binaries/releases/download/90.0.4430.85-1.1/ungoogled_chromium_90.0.4430.85-1.1.AppImage
+md5 = 9cb84485c21ec24d32b530491e750b12
+sha1 = caf383effc22d50c6140d009bd8af1f5b932b0f7
+sha256 = 849075c366b7dd7b1deafc4d3da125370f6cd2fd502f13688bc21f9f0465731d


### PR DESCRIPTION
Latest version based upon https://github.com/ungoogled-software/ungoogled-chromium-portablelinux/tree/master, build with docker