### PR TITLE
Add 90.0.4430.93-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/90.0.4430.93-1.ini
+++ b/config/platforms/archlinux/90.0.4430.93-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-05-04T19:14:37.836299
+github_author = 98WuG
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-90.0.4430.93-1-x86_64.pkg.tar.zst]
+url = https://github.com/98WuG/ungoogled-chromium-binaries/releases/download/90.0.4430.93-1/ungoogled-chromium-90.0.4430.93-1-x86_64.pkg.tar.zst
+md5 = 2a539ffe81a9e9f4428849085f520faf
+sha1 = 1a0d34948051c22006d5e71c7d50362a9fdb4be5
+sha256 = e07ca3d6edff7c7b3d0d2578a7f91d879f368fd52d66c3772ee548b6e94f36bb


### PR DESCRIPTION
Built in a clean chroot with `extra-x86_64-build` as described in https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot.