### PR TITLE
Add 90.0.4430.212-2 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/90.0.4430.212-2.ini
+++ b/config/platforms/archlinux/90.0.4430.212-2.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-05-21T17:01:34.627753
+github_author = 98WuG
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-90.0.4430.212-2-x86_64.pkg.tar.zst]
+url = https://github.com/98WuG/ungoogled-chromium-binaries/releases/download/90.0.4430.212-2/ungoogled-chromium-90.0.4430.212-2-x86_64.pkg.tar.zst
+md5 = b278b67fffaeb44421bb8dffb480db15
+sha1 = 40708b46a4b1527c8a43d791ce86fbd2bf0c2d96
+sha256 = 6e608bbaee85e680e74539b6560d65283d187b60327cba1b5cce316188709f69


### PR DESCRIPTION
Built in a clean chroot with `extra-x86_64-build` as described in https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot.