### PR TITLE
Add 91.0.4472.77-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/91.0.4472.77-1.ini
+++ b/config/platforms/archlinux/91.0.4472.77-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-06-01T17:44:13.607560
+github_author = 98WuG
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-91.0.4472.77-1-x86_64.pkg.tar.zst]
+url = https://github.com/98WuG/ungoogled-chromium-binaries/releases/download/91.0.4472.77-1/ungoogled-chromium-91.0.4472.77-1-x86_64.pkg.tar.zst
+md5 = 09f5f0eff8213434d4007c36f583a385
+sha1 = 56a74f39ad328cadd78d10a68113b5170c8c8f95
+sha256 = fc2326ff5c0c92cfa1357b5aced9b4cc60f50770cd9f8be298eadeec111e4a38


### PR DESCRIPTION
Built in a clean chroot with `extra-x86_64-build` as described in https://wiki.archlinux.org/index.php/DeveloperWiki:Building_in_a_Clean_Chroot.