### PR TITLE
Add new 91.0.4472.77-1 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/91.0.4472.77-1.ini
+++ b/config/platforms/archlinux/91.0.4472.77-1.ini
@@ -1,10 +1,10 @@
 [_metadata]
-publication_time = 2021-06-01T17:44:13.607560
-github_author = 98WuG
+publication_time = 2021-06-05T07:09:10.687835
+github_author = mealwhiles
 # Add a `note` field here for additional information. Markdown is supported
 
-[ungoogled-chromium-91.0.4472.77-1-x86_64.pkg.tar.zst]
-url = https://github.com/98WuG/ungoogled-chromium-binaries/releases/download/91.0.4472.77-1/ungoogled-chromium-91.0.4472.77-1-x86_64.pkg.tar.zst
-md5 = 09f5f0eff8213434d4007c36f583a385
-sha1 = 56a74f39ad328cadd78d10a68113b5170c8c8f95
-sha256 = fc2326ff5c0c92cfa1357b5aced9b4cc60f50770cd9f8be298eadeec111e4a38
+[ungoogled-chromium-91.0.4472.77-1-archlinux-x86_64.tar.xz]
+url = https://github.com/mealwhiles/ungoogled-chromium-binaries/releases/download/91.0.4472.77-1/ungoogled-chromium-91.0.4472.77-1-archlinux-x86_64.tar.xz
+md5 = eaef4b559f507b8a906f9282d4bb755a
+sha1 = 403d7f249fa51f034988a1fc39c31b3214b2b64c
+sha256 = 9793ef2a6be512939f66b59895881ce076e207646492a3f61cfb7e8ba0fa853a


### PR DESCRIPTION
I compiled 91.0.4472.77-1 for Arch Linux then noticed that this version already exists. Is it possible to keep both so users can choose from whom to download the binary?