### PR TITLE
Add 94.0.4606.71 for Arch Linux

### DIFF
--- a/config/platforms/archlinux/94.0.4606.71.ini
+++ b/config/platforms/archlinux/94.0.4606.71.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-10-10T15:55:54.167485
+github_author = Agustyn98
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-94.0.4606.71-1-x86_64.pkg.tar.zst]
+url = https://github.com/Agustyn98/ungoogled-chromium-binaries/releases/download/94.0.4606.71/ungoogled-chromium-94.0.4606.71-1-x86_64.pkg.tar.zst
+md5 = aeb46dc7112238d699c07c1273403e55
+sha1 = 68fec0a173947b5aeb81b589b60bf31e78e7f80e
+sha256 = 276d7194021317d1034f4da023e4551f5be445d6e60c1368be36b962bec6da77


### PR DESCRIPTION
I compiled ungoogled chromium for Arch linux, thought I'd share the package