### PR TITLE
Add 95.0.4638.69-1.1 for Portable Linux 64-bit

### DIFF
--- a/config/platforms/linux_portable/64bit/95.0.4638.69-1.1.ini
+++ b/config/platforms/linux_portable/64bit/95.0.4638.69-1.1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2021-11-08T15:29:11.968191
+github_author = mdedonno1337
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_95.0.4638.69-1.1_linux.tar.xz]
+url = https://github.com/mdedonno1337/ungoogled-chromium-binaries/releases/download/95.0.4638.69-1.1/ungoogled-chromium_95.0.4638.69-1.1_linux.tar.xz
+md5 = cc269c683444526d71622c5451d53d71
+sha1 = 53b895f1e6d09bd9d338fec90f08b48697501ed7
+sha256 = 7dfce737505acc5eca6ccb642a0f6f3b6ebf600e0b00b2227c2caaf18f4f0394


### PR DESCRIPTION
Still compiled with llvm14, I could not port your commit as mentionned in https://github.com/ungoogled-software/ungoogled-chromium-portablelinux/pull/114