### PR TITLE
Add 97.0.4692.71-1 for Manjaro

### DIFF
--- a/config/platforms/manjaro/96.0.4664.110-1.ini
+++ b/config/platforms/manjaro/96.0.4664.110-1.ini
@@ -1,0 +1,16 @@
+[_metadata]
+publication_time = 2022-01-08T17:32:42.531075
+github_author = zocker-160
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-96.0.4664.110-1-Manjaro-build.log]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/96.0.4664.110-1/ungoogled-chromium-96.0.4664.110-1-Manjaro-build.log
+md5 = 01152f94ce1bd187117c24b5794c7801
+sha1 = 56a8b9fece7302755d583d29a24829a2a1369a55
+sha256 = 273f302ba1d7a36e8d3e8c70fb73cc1e290911ff4d13dd27321627a89ef0c5ad
+
+[ungoogled-chromium-96.0.4664.110-1-Manjaro-x86_64.pkg.tar.zst]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/96.0.4664.110-1/ungoogled-chromium-96.0.4664.110-1-Manjaro-x86_64.pkg.tar.zst
+md5 = 05cefe9953d116db30c586da29fe4991
+sha1 = 00607ddd3cf4fd16be5071a919d507b16a61a543
+sha256 = e4e11a90dcd0f92a70c336b51b7007a102e23f1c60d58ee6b4338acaf42ea136

--- a/config/platforms/manjaro/97.0.4692.71-1.ini
+++ b/config/platforms/manjaro/97.0.4692.71-1.ini
@@ -1,0 +1,16 @@
+[_metadata]
+publication_time = 2022-01-08T17:37:23.209946
+github_author = zocker-160
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium-97.0.4692.71-1-Manjaro-build.log]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/97.0.4692.71-1/ungoogled-chromium-97.0.4692.71-1-Manjaro-build.log
+md5 = 6ca8efa39cecf4c6373a2e6d5c614370
+sha1 = 9d4b909a651ddec4a71b1129692fb15d67f44453
+sha256 = 0cdf342bd885463c1780ee96a4d340af2505e7cb24a98d2e99c6721ea2457bab
+
+[ungoogled-chromium-97.0.4692.71-1-Manjaro-x86_64.pkg.tar.zst]
+url = https://github.com/zocker-160/ungoogled-chromium-binaries/releases/download/97.0.4692.71-1/ungoogled-chromium-97.0.4692.71-1-Manjaro-x86_64.pkg.tar.zst
+md5 = 819da5237b92d5f62e8b34bb98e98dd7
+sha1 = c723f1e63f9cae19c91ac133b6dde79d131748b7
+sha256 = cdd19b1c5de9db80b3460ca771e831956d3278e5fb20a9381fa184e3fd66ad5c


### PR DESCRIPTION
Build using the latest Manjaro stable update from 2022-01-02.