### PR TITLE
build for portable linux of ungoogled chromium 100.0.4896.127-1

### DIFF
--- a/config/platforms/appimage/64bit/100.0.4896.127-1.ini
+++ b/config/platforms/appimage/64bit/100.0.4896.127-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2022-04-16T09:27:40.890124
+github_author = clickot
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_100.0.4896.127-1.1.AppImage]
+url = https://github.com/clickot/ungoogled-chromium-binaries/releases/download/100.0.4896.127-1/ungoogled-chromium_100.0.4896.127-1.1.AppImage
+md5 = bc51853da17f00330489f5b61dac041f
+sha1 = bc6221a0f30bf790c58d163fd45808241b701ba5
+sha256 = e584ef52eab445aa96a0f3e413f27753c5938ca91a28338f4596d25918978203

--- a/config/platforms/linux_portable/64bit/100.0.4896.127-1.ini
+++ b/config/platforms/linux_portable/64bit/100.0.4896.127-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2022-04-16T09:27:40.329257
+github_author = clickot
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_100.0.4896.127-1.1_linux.tar.xz]
+url = https://github.com/clickot/ungoogled-chromium-binaries/releases/download/100.0.4896.127-1/ungoogled-chromium_100.0.4896.127-1.1_linux.tar.xz
+md5 = c02ce4a76887ca789848b27b9289955c
+sha1 = b808ada2366a656a15619749cdcd00504cbfff89
+sha256 = dbc71c8fb52a08f42c253a91a0436f94add2d901a6b2adcec2e7a7623134d82e


### PR DESCRIPTION
added assets for build for portable linux of ungoogled chromium 100.0.4896.127-1