### PR TITLE
Add 102.0.5005.115-1 for Windows

### DIFF
--- a/config/platforms/windows/32bit/102.0.5005.115-1.ini
+++ b/config/platforms/windows/32bit/102.0.5005.115-1.ini
@@ -1,0 +1,16 @@
+[_metadata]
+publication_time = 2022-06-16T01:21:25.222734
+github_author = github-actions
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_102.0.5005.115-1.1_installer_x86.exe]
+url = https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/102.0.5005.115-1.1/ungoogled-chromium_102.0.5005.115-1.1_installer_x86.exe
+md5 = e7e385a039eebf695b714271b0e015b6
+sha1 = 73f346d9173f6032ea8a73d7847d31fc483bc805
+sha256 = 73424d296c47fbcc0dff5050f8676adbed4244e154a748765094d64da0862de5
+
+[ungoogled-chromium_102.0.5005.115-1.1_windows_x86.zip]
+url = https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/102.0.5005.115-1.1/ungoogled-chromium_102.0.5005.115-1.1_windows_x86.zip
+md5 = b7f08a9adbdf084f39e132c06aacf33d
+sha1 = e72d81d72e5eb4d91a676bf2948342cce74c33e7
+sha256 = 582874bd96e310dbb867a09a746ba664e0c3a70cd3b21aed9f8477b5894c26e3

--- a/config/platforms/windows/64bit/102.0.5005.115-1.ini
+++ b/config/platforms/windows/64bit/102.0.5005.115-1.ini
@@ -1,0 +1,16 @@
+[_metadata]
+publication_time = 2022-06-16T01:21:17.696609
+github_author = github-actions
+# Add a `note` field here for additional information. Markdown is supported
+
+[ungoogled-chromium_102.0.5005.115-1.1_installer_x64.exe]
+url = https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/102.0.5005.115-1.1/ungoogled-chromium_102.0.5005.115-1.1_installer_x64.exe
+md5 = bd9916c9284cc825a2adf0e5a41688da
+sha1 = 300f763c0e3f4c9266c8d213cfd1148637c105ad
+sha256 = db3ac5e21a1cd8a56d63cb4ecb3d3b8af00fea238fdb4f6c659605633cee7464
+
+[ungoogled-chromium_102.0.5005.115-1.1_windows_x64.zip]
+url = https://github.com/ungoogled-software/ungoogled-chromium-windows/releases/download/102.0.5005.115-1.1/ungoogled-chromium_102.0.5005.115-1.1_windows_x64.zip
+md5 = 2458708d13d289f66c43070a05060438
+sha1 = 74b19b07e46ff62fe07d7de242ba9b892ed5a7cc
+sha256 = c9de72f3f3803c1025a89262d70822ad68990c805c200aa6263cd89fdab25f66


### PR DESCRIPTION
I changed the download links to ungoogled-chromium-windows/releases. I'm not sure if it will break anything. 

Now that we have CI to build releases, I wonder if there is a better way to publish them. 