### PR TITLE
Add 103.0.5060.53-1 binaries for portable linux (rebuilt on debian builder image)

### DIFF
--- a/config/platforms/appimage/64bit/103.0.5060.53-1.ini
+++ b/config/platforms/appimage/64bit/103.0.5060.53-1.ini
@@ -1,10 +1,10 @@
 [_metadata]
-publication_time = 2022-06-23T06:42:56.167602
+publication_time = 2022-06-26T11:37:32.311650
 github_author = clickot
 # Add a `note` field here for additional information. Markdown is supported
 
 [ungoogled-chromium_103.0.5060.53-1.1.AppImage]
 url = https://github.com/clickot/ungoogled-chromium-binaries/releases/download/103.0.5060.53-1/ungoogled-chromium_103.0.5060.53-1.1.AppImage
-md5 = 4bb2b92151256ae20688d875a5aeb08d
-sha1 = 78d421a27fbace7e4e04fe360c5a12aa312324c6
-sha256 = b9452ef3e78181316f6ae3fdcb851ed04df5dd4e17f6078ddefe0f13b4fb5a69
+md5 = d624743ef94972e655fd51805bc0f417
+sha1 = fa5e33dc74c804e108894b87a75a18e3c90a184d
+sha256 = 84817b91d834211f17b2eedbdc85abdbc26a8156fbeb147576c42c9a0dd62956

--- a/config/platforms/linux_portable/64bit/103.0.5060.53-1.ini
+++ b/config/platforms/linux_portable/64bit/103.0.5060.53-1.ini
@@ -1,10 +1,10 @@
 [_metadata]
-publication_time = 2022-06-23T06:42:55.674150
+publication_time = 2022-06-26T11:37:31.835429
 github_author = clickot
 # Add a `note` field here for additional information. Markdown is supported
 
 [ungoogled-chromium_103.0.5060.53-1.1_linux.tar.xz]
 url = https://github.com/clickot/ungoogled-chromium-binaries/releases/download/103.0.5060.53-1/ungoogled-chromium_103.0.5060.53-1.1_linux.tar.xz
-md5 = e08f4a25c1f810da57f79d3afc24a525
-sha1 = 698c661f9c824abdec63685b827736b7cc9dc47e
-sha256 = 93f5572d09050a998a4c53395e34a7fb58119132b02f7f9565e5c4af823f555f
+md5 = 25be017c65d62f3aac3d53b009345b58
+sha1 = e30d62d60a054d7c63acd8f399eb3d13faab54cf
+sha256 = 854d07c4913f65c9a63ef5a53fefe2cd438d89bb5bfd4f35f1279a7be7241431


### PR DESCRIPTION
since the last portable appimage doesn't work on debian (see https://github.com/ungoogled-software/ungoogled-chromium/issues/2001) , i rebuilt it using a debian builder image, resulting in an appimage that works for me both on ubuntu and debian (tested with a ubuntu-jammy installation and a debian bullseye live cd)