### PR TITLE
Add signed macOS builds of 120.0.6099.129-1.1_x86-64__1704447342

### DIFF
--- a/config/platforms/macos/x86_64/120.0.6099.129-1.ini
+++ b/config/platforms/macos/x86_64/120.0.6099.129-1.ini
@@ -1,5 +1,5 @@
 [_metadata]
-publication_time = 2024-01-19T14:29:54Z
+publication_time = 2024-01-19T14:29:54.000000
 github_author = github-actions
 note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
 
@@ -8,4 +8,3 @@ url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/downloa
 md5 = 03623a03f05b63b1dfaea0749718a2ea
 sha1 = 24bca52b00d7bea18f71adbd0f43392c3f5df05e
 sha256 = 39a6089b9b7d6221d36855d11a96df3de432ae813da2831c0c2f15092b2b2453
-

--- a/config/platforms/macos/x86_64/120.0.6099.129-1.ini
+++ b/config/platforms/macos/x86_64/120.0.6099.129-1.ini
@@ -1,0 +1,11 @@
+[_metadata]
+publication_time = 2024-01-19T14:29:54Z
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_120.0.6099.129-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/120.0.6099.129-1.1_x86-64__1704447342/ungoogled-chromium_120.0.6099.129-1.1_x86-64-macos-signed.dmg
+md5 = 03623a03f05b63b1dfaea0749718a2ea
+sha1 = 24bca52b00d7bea18f71adbd0f43392c3f5df05e
+sha256 = 39a6089b9b7d6221d36855d11a96df3de432ae813da2831c0c2f15092b2b2453
+


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/7654412834) by the release of [code-signed build 120.0.6099.129-1.1_x86-64__1704447342](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/120.0.6099.129-1.1_x86-64__1704447342) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/120.0.6099.129-1.1_x86-64__1704447342).