### PR TITLE
Add signed macOS builds of 120.0.6099.129-1.1_arm64__1704473311

### DIFF
--- a/config/platforms/macos/arm64/120.0.6099.129-1.ini
+++ b/config/platforms/macos/arm64/120.0.6099.129-1.ini
@@ -1,5 +1,5 @@
 [_metadata]
-publication_time = 2024-01-25T10:34:55Z
+publication_time = 2024-01-25T10:34:55.000000
 github_author = github-actions
 note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
 
@@ -8,4 +8,3 @@ url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/downloa
 md5 = 8f350395ac173f4f27ea46f079525872
 sha1 = b85d43ba0c3ba13804098a1398fc5609536957c3
 sha256 = 5549ed053acbda22b66d30468c6d34824b94393707c350be0ee5bf8b5aa6021c
-

--- a/config/platforms/macos/arm64/120.0.6099.129-1.ini
+++ b/config/platforms/macos/arm64/120.0.6099.129-1.ini
@@ -1,0 +1,11 @@
+[_metadata]
+publication_time = 2024-01-25T10:34:55Z
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_120.0.6099.129-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/120.0.6099.129-1.1_arm64__1704473311/ungoogled-chromium_120.0.6099.129-1.1_arm64-macos-signed.dmg
+md5 = 8f350395ac173f4f27ea46f079525872
+sha1 = b85d43ba0c3ba13804098a1398fc5609536957c3
+sha256 = 5549ed053acbda22b66d30468c6d34824b94393707c350be0ee5bf8b5aa6021c
+


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/7654414507) by the release of [code-signed build 120.0.6099.129-1.1_arm64__1704473311](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/120.0.6099.129-1.1_arm64__1704473311) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/120.0.6099.129-1.1_arm64__1704473311).