### PR TITLE
Add signed macOS builds of 121.0.6167.85-1.1__1706477461

### DIFF
--- a/config/platforms/macos/arm64/121.0.6167.85-1.ini
+++ b/config/platforms/macos/arm64/121.0.6167.85-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-01-28T21:46:55.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.85-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.85-1.1__1706477461/ungoogled-chromium_121.0.6167.85-1.1_arm64-macos-signed.dmg
+md5 = e1465032aa893925abea85c986ad1582
+sha1 = 7d6ae0dbc8fa4c6b8ed5afb48780375a526af2e5
+sha256 = 34bf08dc7eca3a95a099194c334b8987fadb7cb1c1d1c412084d175cc580064a

--- a/config/platforms/macos/x86_64/121.0.6167.85-1.ini
+++ b/config/platforms/macos/x86_64/121.0.6167.85-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-01-28T21:46:55.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.85-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.85-1.1__1706477461/ungoogled-chromium_121.0.6167.85-1.1_x86-64-macos-signed.dmg
+md5 = 2cc528c65189543a72b166777dfdf232
+sha1 = 90d6b9ccbc4ad3bc29b85239c73d833b1b9de784
+sha256 = 531e0e1434dcac65523ba1533f89bdf750c17b173112105013f03dd580f95c74


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/7688600217) by the release of [code-signed build 121.0.6167.85-1.1__1706477461](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/121.0.6167.85-1.1__1706477461) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/121.0.6167.85-1.1__1706477461).