### PR TITLE
Add signed macOS builds of 121.0.6167.139-1.1

### DIFF
--- a/config/platforms/macos/arm64/121.0.6167.139-1.ini
+++ b/config/platforms/macos/arm64/121.0.6167.139-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-04T14:46:47.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.139-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.139-1.1/ungoogled-chromium_121.0.6167.139-1.1_arm64-macos-signed.dmg
+md5 = c207d0a2443a6eebddee5adf9c32b612
+sha1 = 1a1ccae3f7f8b0e3d539800435aa5bb48d2aae5a
+sha256 = 4fef4f657496d787d95ba772a0cfc35007db7cbed5efbd21a5409cd395c2c87e

--- a/config/platforms/macos/x86_64/121.0.6167.139-1.ini
+++ b/config/platforms/macos/x86_64/121.0.6167.139-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-04T14:46:47.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.139-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.139-1.1/ungoogled-chromium_121.0.6167.139-1.1_x86-64-macos-signed.dmg
+md5 = df03cc872f2985fb4586b3184a36d02e
+sha1 = 1d7a2857b22f10ce1d2be9aa2bb9e8d6a7c3982c
+sha256 = 7665132219d300ba13586cec3233823665f664709e80d9eb635052e3e38198ea


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/7774829176) by the release of [code-signed build 121.0.6167.139-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/121.0.6167.139-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/121.0.6167.139-1.1).