### PR TITLE
Migrate Cirrus's site_generation workflow to Github Actions

### DIFF
--- a/.github/workflows/site_generation.yml
+++ b/.github/workflows/site_generation.yml
@@ -1,0 +1,25 @@
+name: Site generation
+
+on:
+  pull_request:
+
+jobs:
+  site_generation:
+    runs-on: ubuntu-latest
+    name: Site generation
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - name: Run pip_install
+        run: pip install -r utilities/requirements.txt
+      - name: Run check_config
+        run: ./.cirrus_get_filelist.py | ./utilities/check_platform_ini.py -
+      - name: Run site_generator
+        run: |
+          git diff --cached --exit-code
+          git diff --exit-code
+          python3 utilities/site_generator.py


### PR DESCRIPTION
This hopefully closes #494

I'm not sure whether this works or whether I'm missing something important that isn't publicly visible, but this attempts to replace Cirrus CI's workflow with Github Actions based on this run: https://cirrus-ci.com/task/4779247017918464

Specifically, this runs the `check_config` and `site_generator` tasks whenever a PR is opened.