### PR TITLE
Add signed macOS builds of 121.0.6167.160-1.1

### DIFF
--- a/config/platforms/macos/arm64/121.0.6167.160-1.ini
+++ b/config/platforms/macos/arm64/121.0.6167.160-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-10T17:10:47.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.160-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.160-1.1/ungoogled-chromium_121.0.6167.160-1.1_arm64-macos-signed.dmg
+md5 = 7b7a6c84f2ccdcaef0bcd854d7220d25
+sha1 = afcc2b3d441872e71521bcaf96eeb3c59db3ed99
+sha256 = 6e903998e362d005f36e2b4eaff63a1f86a89ca38e26f69eee846d2e1cfe2ab9

--- a/config/platforms/macos/x86_64/121.0.6167.160-1.ini
+++ b/config/platforms/macos/x86_64/121.0.6167.160-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-10T17:10:47.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.160-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.160-1.1/ungoogled-chromium_121.0.6167.160-1.1_x86-64-macos-signed.dmg
+md5 = f38bc298dade1a98f365cb5c861da40d
+sha1 = df1e739920ffbde0060d92a6f25c8fe61aac7919
+sha256 = ba560a28d46011f3f804b0c1210b507471dfe84836de713bbde475bec71a7a66


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/7856292060) by the release of [code-signed build 121.0.6167.160-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/121.0.6167.160-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/121.0.6167.160-1.1).