### PR TITLE
Add signed macOS builds of 121.0.6167.184-1.1

### DIFF
--- a/config/platforms/macos/arm64/121.0.6167.184-1.ini
+++ b/config/platforms/macos/arm64/121.0.6167.184-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-15T10:08:51.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.184-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.184-1.1/ungoogled-chromium_121.0.6167.184-1.1_arm64-macos-signed.dmg
+md5 = 2e188a4d051aa36d37b4985620f98da7
+sha1 = a9e9fd6900afa555b8ef2cf2288910ba89aef578
+sha256 = 57f79b2ff37aa44f932c1e2cb53ed3ea011663547d940b37e490aac15202133f

--- a/config/platforms/macos/x86_64/121.0.6167.184-1.ini
+++ b/config/platforms/macos/x86_64/121.0.6167.184-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-15T10:08:51.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_121.0.6167.184-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/121.0.6167.184-1.1/ungoogled-chromium_121.0.6167.184-1.1_x86-64-macos-signed.dmg
+md5 = b7a8e706e0c8e4f5f51bc75765b24354
+sha1 = 3b1819a3d37512ead1ad61973e2b379d7e8a2e1f
+sha256 = b1aabac88b4175da1c0e8f6aa3bb8750a470ac9190309548bec776268207f9a2


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/7914221956) by the release of [code-signed build 121.0.6167.184-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/121.0.6167.184-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/121.0.6167.184-1.1).