### PR TITLE
Add signed macOS builds of 122.0.6261.69-1.1

### DIFF
--- a/config/platforms/macos/arm64/122.0.6261.69-1.ini
+++ b/config/platforms/macos/arm64/122.0.6261.69-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-26T11:46:42.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_122.0.6261.69-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/122.0.6261.69-1.1/ungoogled-chromium_122.0.6261.69-1.1_arm64-macos-signed.dmg
+md5 = 9e8490d8c12fc248dc8f740a9aa408d7
+sha1 = fb3cb8668c8142e7e800a080c526e81a4a24bc01
+sha256 = 3a7f5e583f66640d9d84a91e87e2d5e379153d33e76df528f93da5a8fd8cd45b

--- a/config/platforms/macos/x86_64/122.0.6261.69-1.ini
+++ b/config/platforms/macos/x86_64/122.0.6261.69-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-02-26T11:46:42.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_122.0.6261.69-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/122.0.6261.69-1.1/ungoogled-chromium_122.0.6261.69-1.1_x86-64-macos-signed.dmg
+md5 = e2377bf4ff9ebcb3d71683d68eb7132a
+sha1 = d67dc423f88f6ccbfe9bea9c8b7eea2a9c843f48
+sha256 = d69a6a9e98c445ddbbbd065bd3b08b7adda368ee1bb3800061e5fc273923ab73


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8048321777) by the release of [code-signed build 122.0.6261.69-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/122.0.6261.69-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/122.0.6261.69-1.1).