### PR TITLE
Add signed macOS builds of 122.0.6261.94-1.1

### DIFF
--- a/config/platforms/macos/arm64/122.0.6261.94-1.ini
+++ b/config/platforms/macos/arm64/122.0.6261.94-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-03-03T12:10:45.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_122.0.6261.94-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/122.0.6261.94-1.1/ungoogled-chromium_122.0.6261.94-1.1_arm64-macos-signed.dmg
+md5 = 7fbdcd78b559ce9082a0e07e2c3344af
+sha1 = 3ecea715cc6722bc57ca6feff62d9a672341f989
+sha256 = cb0317c965ae6fda5e036d931a92056862cc461cca3bcf3e8fd3fa90dfc72bbc

--- a/config/platforms/macos/x86_64/122.0.6261.94-1.ini
+++ b/config/platforms/macos/x86_64/122.0.6261.94-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-03-03T12:10:45.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_122.0.6261.94-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/122.0.6261.94-1.1/ungoogled-chromium_122.0.6261.94-1.1_x86-64-macos-signed.dmg
+md5 = cd2426fb549b62af09c3e8182fe86f31
+sha1 = d876fde4a0150ff8cf3b5f5c6cd2dbf1aa0960a5
+sha256 = 613ba0679e01745838f03383cab0b43bd33a8452f4538982392ecec4aae83f1e


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8130048686) by the release of [code-signed build 122.0.6261.94-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/122.0.6261.94-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/122.0.6261.94-1.1).