### PR TITLE
Add signed macOS builds of 122.0.6261.111-1.1

### DIFF
--- a/config/platforms/macos/arm64/122.0.6261.111-1.ini
+++ b/config/platforms/macos/arm64/122.0.6261.111-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-03-09T08:46:37.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_122.0.6261.111-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/122.0.6261.111-1.1/ungoogled-chromium_122.0.6261.111-1.1_arm64-macos-signed.dmg
+md5 = 9b472b2f8806e2d49b2224732bf9b480
+sha1 = 3d182b610fea38bb2850612de24c9a956a60224c
+sha256 = f573c963a88afd96fe4d9671811817ea4f9116c3d7505c05e8483abf58064afe

--- a/config/platforms/macos/arm64/122.0.6261.111-1.ini
+++ b/config/platforms/macos/arm64/122.0.6261.111-1.ini
@@ -1,6 +1,6 @@
 [_metadata]
 publication_time = 2024-03-09T08:46:37.000000
-github_author = github-actions
+github_author = claudiodekker
 note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
 
 [ungoogled-chromium_122.0.6261.111-1.1_arm64-macos-signed.dmg]

--- a/config/platforms/macos/x86_64/122.0.6261.111-1.ini
+++ b/config/platforms/macos/x86_64/122.0.6261.111-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-03-09T08:46:37.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_122.0.6261.111-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/122.0.6261.111-1.1/ungoogled-chromium_122.0.6261.111-1.1_x86-64-macos-signed.dmg
+md5 = 2f899f464e27019d12c82ca19a88bdda
+sha1 = 2dfbf79c7cd83024df90a709541dfb85032726e2
+sha256 = 20113b61eeb3b75492cc705db2c0759cdb4b291a8cae593b71e9f9beff38ada8

--- a/config/platforms/macos/x86_64/122.0.6261.111-1.ini
+++ b/config/platforms/macos/x86_64/122.0.6261.111-1.ini
@@ -1,6 +1,6 @@
 [_metadata]
 publication_time = 2024-03-09T08:46:37.000000
-github_author = github-actions
+github_author = claudiodekker
 note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
 
 [ungoogled-chromium_122.0.6261.111-1.1_x86-64-macos-signed.dmg]


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8213421557) by the release of [code-signed build 122.0.6261.111-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/122.0.6261.111-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/122.0.6261.111-1.1).