### PR TITLE
Add signed macOS builds of 123.0.6312.86-1.1

### DIFF
--- a/config/platforms/macos/arm64/123.0.6312.86-1.ini
+++ b/config/platforms/macos/arm64/123.0.6312.86-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-04-01T11:55:17.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_123.0.6312.86-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/123.0.6312.86-1.1/ungoogled-chromium_123.0.6312.86-1.1_arm64-macos-signed.dmg
+md5 = 1d39ad58aa25e678ed3f6b533b65adec
+sha1 = ad3fa12bde8b4a89fcbf1f438911babf110a182f
+sha256 = bc5136f7c15c234c1a7efca4aa805eb73924a1971941b32bbb232a593dab6e5a

--- a/config/platforms/macos/arm64/123.0.6312.86-1.ini
+++ b/config/platforms/macos/arm64/123.0.6312.86-1.ini
@@ -1,6 +1,6 @@
 [_metadata]
 publication_time = 2024-04-01T11:55:17.000000
-github_author = github-actions
+github_author = claudiodekker
 note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
 
 [ungoogled-chromium_123.0.6312.86-1.1_arm64-macos-signed.dmg]

--- a/config/platforms/macos/x86_64/123.0.6312.86-1.ini
+++ b/config/platforms/macos/x86_64/123.0.6312.86-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-04-01T11:55:17.000000
+github_author = github-actions
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_123.0.6312.86-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/123.0.6312.86-1.1/ungoogled-chromium_123.0.6312.86-1.1_x86-64-macos-signed.dmg
+md5 = f809ef51c306fbcd13d0b099291447fc
+sha1 = 5a74cd9eecffb44cc80dc08d9ae501a735952f7c
+sha256 = 360b7e712c9afc3c2b1289eb0af67e3ca15b2456e8f9b64e71ba286b74c13d11

--- a/config/platforms/macos/x86_64/123.0.6312.86-1.ini
+++ b/config/platforms/macos/x86_64/123.0.6312.86-1.ini
@@ -1,6 +1,6 @@
 [_metadata]
 publication_time = 2024-04-01T11:55:17.000000
-github_author = github-actions
+github_author = claudiodekker
 note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
 
 [ungoogled-chromium_123.0.6312.86-1.1_x86-64-macos-signed.dmg]


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8507710155) by the release of [code-signed build 123.0.6312.86-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/123.0.6312.86-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/123.0.6312.86-1.1).