### PR TITLE
Add signed macOS builds of 123.0.6312.105-1.1

### DIFF
--- a/config/platforms/macos/arm64/123.0.6312.105-1.ini
+++ b/config/platforms/macos/arm64/123.0.6312.105-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-04-06T05:32:09.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_123.0.6312.105-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/123.0.6312.105-1.1/ungoogled-chromium_123.0.6312.105-1.1_arm64-macos-signed.dmg
+md5 = 55e1fa322e48ac40f11ad7e1271a247e
+sha1 = 64d48d9a1c7a84eada1d66f257dc4236bd6eed59
+sha256 = 490a875eeaa43e7423d824b2c206a895d21e1d5edff0ed22b824c461e34615dd

--- a/config/platforms/macos/x86_64/123.0.6312.105-1.ini
+++ b/config/platforms/macos/x86_64/123.0.6312.105-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-04-06T05:32:09.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_123.0.6312.105-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/123.0.6312.105-1.1/ungoogled-chromium_123.0.6312.105-1.1_x86-64-macos-signed.dmg
+md5 = 55ce0d11a44cb22acc2b2d142026d78e
+sha1 = 4c315c5a803a7f10463ecef04d08a95a7d943c56
+sha256 = ffee5aff8441fc9a8f832d2aa346a6332cd35165f5d0fb06e2457c56bec76cf2


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8579048115) by the release of [code-signed build 123.0.6312.105-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/123.0.6312.105-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/123.0.6312.105-1.1).