### PR TITLE
Add signed macOS builds of 124.0.6367.91-1.1

### DIFF
--- a/config/platforms/macos/arm64/124.0.6367.91-1.ini
+++ b/config/platforms/macos/arm64/124.0.6367.91-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-04-28T15:08:37.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_124.0.6367.91-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/124.0.6367.91-1.1/ungoogled-chromium_124.0.6367.91-1.1_arm64-macos-signed.dmg
+md5 = e9dc6e944259c7cce08f4f8f56dea11d
+sha1 = 821c2db3e0ad645584b8119a2eeef8f133728b21
+sha256 = ca760c36a7cf957a01a83e5961917e52d49fa66c80964f433bd90c491d546f06

--- a/config/platforms/macos/x86_64/124.0.6367.91-1.ini
+++ b/config/platforms/macos/x86_64/124.0.6367.91-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-04-28T15:08:37.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_124.0.6367.91-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/124.0.6367.91-1.1/ungoogled-chromium_124.0.6367.91-1.1_x86-64-macos-signed.dmg
+md5 = 8c9f882e8f85e27d2e8d652bd731a0a6
+sha1 = 9dd90746162bf0b6eb8446bad450d2cd0b4e61f3
+sha256 = 63fb510de6bed81e7cb679f5b0c82bee3a19f43a7e314a85a56cc942a6b23488


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8868494509) by the release of [code-signed build 124.0.6367.91-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/124.0.6367.91-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/124.0.6367.91-1.1).