### PR TITLE
Add signed macOS builds of 124.0.6367.118-1.1

### DIFF
--- a/config/platforms/macos/arm64/124.0.6367.118-1.ini
+++ b/config/platforms/macos/arm64/124.0.6367.118-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-05T16:08:48.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_124.0.6367.118-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/124.0.6367.118-1.1/ungoogled-chromium_124.0.6367.118-1.1_arm64-macos-signed.dmg
+md5 = c9208d6dd1edd63a06ebc0d6351272c8
+sha1 = 5f96d4275a02c4755abef6eb9a89a7541429da56
+sha256 = f28076954b3ed4478b1eae09c7da2ffc4f877dac545352d1e514a121316f533b

--- a/config/platforms/macos/x86_64/124.0.6367.118-1.ini
+++ b/config/platforms/macos/x86_64/124.0.6367.118-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-05T16:08:48.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_124.0.6367.118-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/124.0.6367.118-1.1/ungoogled-chromium_124.0.6367.118-1.1_x86-64-macos-signed.dmg
+md5 = ef351c9f66ee165df5d5c4ff96f2171c
+sha1 = 476a3e21fb62dbc2f21fef7e133003d297887a45
+sha256 = 1022671ede0db7456d332239cdb34e177b7884c7de0f145e3d3985ffd45d1bfd


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/8959517034) by the release of [code-signed build 124.0.6367.118-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/124.0.6367.118-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/124.0.6367.118-1.1).