### PR TITLE
Add signed macOS builds of 124.0.6367.207-1.1

### DIFF
--- a/config/platforms/macos/arm64/124.0.6367.207-1.ini
+++ b/config/platforms/macos/arm64/124.0.6367.207-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-15T06:31:18.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_124.0.6367.207-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/124.0.6367.207-1.1/ungoogled-chromium_124.0.6367.207-1.1_arm64-macos-signed.dmg
+md5 = fef699dbffdb8d90873507996590cf42
+sha1 = 934b574c3e0f3c8887cf2eb18143dd930c93bc0d
+sha256 = 295e8510e723ccd8c45d8dac7a6046beadf963315b3c200eda94c95637d63496

--- a/config/platforms/macos/x86_64/124.0.6367.207-1.ini
+++ b/config/platforms/macos/x86_64/124.0.6367.207-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-15T06:31:18.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_124.0.6367.207-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/124.0.6367.207-1.1/ungoogled-chromium_124.0.6367.207-1.1_x86-64-macos-signed.dmg
+md5 = c9b2c1e6da8245b90f7a1dbce3a78d31
+sha1 = 4953222d58378bc4f7ff4dffb0a29ad02263a60e
+sha256 = 161d489693e9e44f27b19023c6e6988c348569b62bca0d07960377ecfd9693eb


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9091065770) by the release of [code-signed build 124.0.6367.207-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/124.0.6367.207-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/124.0.6367.207-1.1).