### PR TITLE
Add signed macOS builds of 125.0.6422.60-1.1

### DIFF
--- a/config/platforms/macos/arm64/125.0.6422.60-1.ini
+++ b/config/platforms/macos/arm64/125.0.6422.60-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-20T17:08:41.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_125.0.6422.60-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/125.0.6422.60-1.1/ungoogled-chromium_125.0.6422.60-1.1_arm64-macos-signed.dmg
+md5 = 3f6d5fa12abc8dfa45f49693a674b42a
+sha1 = 46999593345c1c46138ff61b145f2744129e5b89
+sha256 = 3599906cb9790b177e6fa3073124eaeb73ded4bc929547ff4660bf73719d016c

--- a/config/platforms/macos/x86_64/125.0.6422.60-1.ini
+++ b/config/platforms/macos/x86_64/125.0.6422.60-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-20T17:08:41.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_125.0.6422.60-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/125.0.6422.60-1.1/ungoogled-chromium_125.0.6422.60-1.1_x86-64-macos-signed.dmg
+md5 = be8d0397a07a3e1523dfbed5f761476b
+sha1 = d4f4578a391d574859f153130ef8b50e51a50c56
+sha256 = 9888a8f6bd29eee58d3f6b676252a2e6ad0b511473201397b689188df4e1d265


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9162335659) by the release of [code-signed build 125.0.6422.60-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/125.0.6422.60-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/125.0.6422.60-1.1).