### PR TITLE
Add signed macOS builds of 125.0.6422.112-1.1

### DIFF
--- a/config/platforms/macos/arm64/125.0.6422.112-1.ini
+++ b/config/platforms/macos/arm64/125.0.6422.112-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-05-27T11:46:35.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_125.0.6422.112-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/125.0.6422.112-1.1/ungoogled-chromium_125.0.6422.112-1.1_arm64-macos-signed.dmg
+md5 = 7e34c661afee77b40b50b9061a7c689d
+sha1 = 9006b6db018b91602cb4920db7425d2d59b747d1
+sha256 = 6d6fdca580b1a44bab62d310f61c9f0b37e4956d754526d7703ba59bec61a2b8


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9254256385) by the release of [code-signed build 125.0.6422.112-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/125.0.6422.112-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/125.0.6422.112-1.1).