### PR TITLE
Add signed macOS builds of 125.0.6422.141-1.1

### DIFF
--- a/config/platforms/macos/arm64/125.0.6422.141-1.ini
+++ b/config/platforms/macos/arm64/125.0.6422.141-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-01T16:31:38.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_125.0.6422.141-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/125.0.6422.141-1.1/ungoogled-chromium_125.0.6422.141-1.1_arm64-macos-signed.dmg
+md5 = 366e5c142c4617f36e972f40bcc5d7fe
+sha1 = 3a41712bedfa8c6dd7ff09631f0f72f1d7765d65
+sha256 = 12c35bc68967de0a41a8a999b7fe2284586539f00a527e02acfba01440f9cd69

--- a/config/platforms/macos/x86_64/125.0.6422.141-1.ini
+++ b/config/platforms/macos/x86_64/125.0.6422.141-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-01T16:31:38.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_125.0.6422.141-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/125.0.6422.141-1.1/ungoogled-chromium_125.0.6422.141-1.1_x86-64-macos-signed.dmg
+md5 = d146ba7ea9ff709e98e6df9a92650109
+sha1 = cbd227bbd33ec57a63a786b571bd12b736ee2070
+sha256 = 09849d2aeb46b509e5aee6ddab1bed002201e1e02f0b19d8291c1a91d9e9edd9


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9331687096) by the release of [code-signed build 125.0.6422.141-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/125.0.6422.141-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/125.0.6422.141-1.1).