### PR TITLE
Add signed macOS builds of 126.0.6478.61-1.1

### DIFF
--- a/config/platforms/macos/arm64/126.0.6478.61-1.ini
+++ b/config/platforms/macos/arm64/126.0.6478.61-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-19T13:46:25.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.61-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.61-1.1/ungoogled-chromium_126.0.6478.61-1.1_arm64-macos-signed.dmg
+md5 = 2972c5006165390f15df3aeb83d2f778
+sha1 = f283f22b2461d33a9952b4c5896d038e8b140f98
+sha256 = 5a691f1db4789728bbea48eb54da99e803c0f6bdd5195229f9cc9a6e313a98c3

--- a/config/platforms/macos/x86_64/126.0.6478.61-1.ini
+++ b/config/platforms/macos/x86_64/126.0.6478.61-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-19T13:46:25.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.61-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.61-1.1/ungoogled-chromium_126.0.6478.61-1.1_x86-64-macos-signed.dmg
+md5 = 42f483cc626ddabf5dd5a064c14e9995
+sha1 = 48520490dfa0321eb9a84625dea9a315ece2ae56
+sha256 = e1b6fa0a5c9064472cc508dd79ac004b5db6756260d4e7a52c179bd46b2a5fe7


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9583163037) by the release of [code-signed build 126.0.6478.61-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/126.0.6478.61-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/126.0.6478.61-1.1).