### PR TITLE
Add signed macOS builds of 126.0.6478.114-1.1

### DIFF
--- a/config/platforms/macos/arm64/126.0.6478.114-1.ini
+++ b/config/platforms/macos/arm64/126.0.6478.114-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-21T06:35:52.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.114-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.114-1.1/ungoogled-chromium_126.0.6478.114-1.1_arm64-macos-signed.dmg
+md5 = c95754eb820d5fd5b56079bb98a8e239
+sha1 = 86998c4ac3ba250c5ccdfdaf7e77016a63a53181
+sha256 = f169970787d894fe2a33e52030d413fae020156cc8be3aa59830ae32039346d7

--- a/config/platforms/macos/x86_64/126.0.6478.114-1.ini
+++ b/config/platforms/macos/x86_64/126.0.6478.114-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-21T06:35:52.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.114-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.114-1.1/ungoogled-chromium_126.0.6478.114-1.1_x86-64-macos-signed.dmg
+md5 = cbd73a57062875ea3dd0431d10be738c
+sha1 = b4ddf01db1a95aca85a6aee6609588c806984c18
+sha256 = 9afda55c0e72b0f16d5ff1ba2448e8c596facdbe27f56104127d57d36bccf178


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9609393268) by the release of [code-signed build 126.0.6478.114-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/126.0.6478.114-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/126.0.6478.114-1.1).