### PR TITLE
Add signed macOS builds of 126.0.6478.126-1.1

### DIFF
--- a/config/platforms/macos/arm64/126.0.6478.126-1.ini
+++ b/config/platforms/macos/arm64/126.0.6478.126-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-27T08:09:50.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.126-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.126-1.1/ungoogled-chromium_126.0.6478.126-1.1_arm64-macos-signed.dmg
+md5 = 84d0638cabdb9151a81db436aa7034dc
+sha1 = b0484ab89d2c9bc1898b793279e620c5155a7e78
+sha256 = 7d6fb9130c586bd0706b48c85520acf028ad8eeb2e631b382dce2270005cd594

--- a/config/platforms/macos/x86_64/126.0.6478.126-1.ini
+++ b/config/platforms/macos/x86_64/126.0.6478.126-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-06-27T08:09:50.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.126-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.126-1.1/ungoogled-chromium_126.0.6478.126-1.1_x86-64-macos-signed.dmg
+md5 = 46a5a780e6f473b1d7e52d525aaaa0b8
+sha1 = e4e480bea873705acd1f4c7fa6ba8437f153ca50
+sha256 = a71e397f4b57068fe05335dda5bee2ed9b442c72e08e13050ec630f5786ec4e4


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/9692994542) by the release of [code-signed build 126.0.6478.126-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/126.0.6478.126-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/126.0.6478.126-1.1).