### PR TITLE
Add signed macOS builds of 126.0.6478.182-1.1

### DIFF
--- a/config/platforms/macos/arm64/126.0.6478.182-1.ini
+++ b/config/platforms/macos/arm64/126.0.6478.182-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-07-19T08:31:01.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.182-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.182-1.1/ungoogled-chromium_126.0.6478.182-1.1_arm64-macos-signed.dmg
+md5 = b3cf7a3489aec6ed17e90185b600a339
+sha1 = 7fc6e31b86987808a3e452c8023d1debeb77ea28
+sha256 = 047fbbf8f7a7af7ddf8b515c036a99186eaaab605c2c5ff5e7176ef6373ddeda

--- a/config/platforms/macos/x86_64/126.0.6478.182-1.ini
+++ b/config/platforms/macos/x86_64/126.0.6478.182-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-07-19T08:31:01.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_126.0.6478.182-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/126.0.6478.182-1.1/ungoogled-chromium_126.0.6478.182-1.1_x86-64-macos-signed.dmg
+md5 = a5a96c20cd48aae30d967319bea59367
+sha1 = 40279010794bbab353253037f993c86c82cf68e7
+sha256 = c486ed20df50447896a8ab7e52a80e8281bb9909e017d066d54a20aaad048384


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10005062429) by the release of [code-signed build 126.0.6478.182-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/126.0.6478.182-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/126.0.6478.182-1.1).