### PR TITLE
Add signed macOS builds of 127.0.6533.72-1.1

### DIFF
--- a/config/platforms/macos/arm64/127.0.6533.72-1.ini
+++ b/config/platforms/macos/arm64/127.0.6533.72-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-07-30T12:53:27.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.72-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.72-1.1/ungoogled-chromium_127.0.6533.72-1.1_arm64-macos-signed.dmg
+md5 = 3ec3589352d8ba716e09f8422a103027
+sha1 = bc18489a7cf43a50775f7babbe09be337d2c24f9
+sha256 = 79e39609a064f2d1f4c0ba4c12c6a789acf767e18bdd95eea0e6c6fa9b06c90e

--- a/config/platforms/macos/x86_64/127.0.6533.72-1.ini
+++ b/config/platforms/macos/x86_64/127.0.6533.72-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-07-30T12:53:27.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.72-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.72-1.1/ungoogled-chromium_127.0.6533.72-1.1_x86-64-macos-signed.dmg
+md5 = 4b6330a1a5ea353f4ca837730c362b8c
+sha1 = b4e604c83cf99d7979e0d2a420cf160ed927438d
+sha256 = 961eca774c83f619f784a49e8dc11be4aef676874002b7b47211cb22935f4a19


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10162729174) by the release of [code-signed build 127.0.6533.72-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/127.0.6533.72-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/127.0.6533.72-1.1).