### PR TITLE
Add signed macOS builds of 127.0.6533.88-1.1

### DIFF
--- a/config/platforms/macos/arm64/127.0.6533.88-1.ini
+++ b/config/platforms/macos/arm64/127.0.6533.88-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-03T10:30:40.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.88-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.88-1.1/ungoogled-chromium_127.0.6533.88-1.1_arm64-macos-signed.dmg
+md5 = 9df072b0a1be215dc078affc8136833d
+sha1 = efac14c4ce446c0ad1bc1e06981c854c51d752bc
+sha256 = e18a0561366b1b551ec4c814d90390f55f9ce26126ab250769465d01f55ece46

--- a/config/platforms/macos/x86_64/127.0.6533.88-1.ini
+++ b/config/platforms/macos/x86_64/127.0.6533.88-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-03T10:30:40.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.88-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.88-1.1/ungoogled-chromium_127.0.6533.88-1.1_x86-64-macos-signed.dmg
+md5 = 4f1d5750091db81d97db228340ce28ed
+sha1 = eb568bfe0fbd126b3d9c2efb20cc3805b3818cd9
+sha256 = 45bd376832e4dbf51a472d99218e61d58b406ff25bc41bcc93de7f3b73ee84c5


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10227334870) by the release of [code-signed build 127.0.6533.88-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/127.0.6533.88-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/127.0.6533.88-1.1).