### PR TITLE
Add signed macOS builds of 127.0.6533.99-1.1

### DIFF
--- a/config/platforms/macos/arm64/127.0.6533.99-1.ini
+++ b/config/platforms/macos/arm64/127.0.6533.99-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-10T11:46:19.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.99-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.99-1.1/ungoogled-chromium_127.0.6533.99-1.1_arm64-macos-signed.dmg
+md5 = 9fc8c784b6bf0c910d273bcc7f63bfac
+sha1 = 98580c25f359d8c061b7eb58a1cad4d54587fcf6
+sha256 = 7ba642c1854be99ecc8487f9d79cb3cd8ffff690cf9960a3475e2de0778eecc3

--- a/config/platforms/macos/x86_64/127.0.6533.99-1.ini
+++ b/config/platforms/macos/x86_64/127.0.6533.99-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-10T11:46:19.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.99-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.99-1.1/ungoogled-chromium_127.0.6533.99-1.1_x86-64-macos-signed.dmg
+md5 = 03f40276cc443dfb202153e942740bce
+sha1 = a705797da456b240ee3c35b9ef4d1fb30b1b6ea5
+sha256 = 5949b2bbd3f5cb9c93ef9b94bad7659dec4a0846cdd310d4595f4fe25bce92f8


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10331337896) by the release of [code-signed build 127.0.6533.99-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/127.0.6533.99-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/127.0.6533.99-1.1).