### PR TITLE
Add signed macOS builds of 127.0.6533.119-1.1

### DIFF
--- a/config/platforms/macos/arm64/127.0.6533.119-1.ini
+++ b/config/platforms/macos/arm64/127.0.6533.119-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-15T19:08:34.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.119-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.119-1.1/ungoogled-chromium_127.0.6533.119-1.1_arm64-macos-signed.dmg
+md5 = 11dbd67c07790ab14c4b88bd08f0c62f
+sha1 = 3698316caa14b3ad57421b39424c3c10895a4e47
+sha256 = da610d8c7390fdc3754a8fbb5e194e031fd0d21926df1ff829c69d3cadeb7023

--- a/config/platforms/macos/x86_64/127.0.6533.119-1.ini
+++ b/config/platforms/macos/x86_64/127.0.6533.119-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-15T19:08:34.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_127.0.6533.119-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/127.0.6533.119-1.1/ungoogled-chromium_127.0.6533.119-1.1_x86-64-macos-signed.dmg
+md5 = 18bcb66f26bef45508a72f042ee08f4b
+sha1 = d512e2d1de137de5df534a93f8f48a4aac8ac96a
+sha256 = 06549d0037db7b83d24982196b698944722d941de5b58ec30780fb62b459fd0a


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10409139236) by the release of [code-signed build 127.0.6533.119-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/127.0.6533.119-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/127.0.6533.119-1.1).