### PR TITLE
Add signed macOS builds of 128.0.6613.84-1.1

### DIFF
--- a/config/platforms/macos/arm64/128.0.6613.84-1.ini
+++ b/config/platforms/macos/arm64/128.0.6613.84-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-25T14:46:21.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_128.0.6613.84-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/128.0.6613.84-1.1/ungoogled-chromium_128.0.6613.84-1.1_arm64-macos-signed.dmg
+md5 = e0e0bd44eb3bff78e9cc7cdeaea4aa88
+sha1 = 7b70ee5bc4b6ed8394f775d10cb3cd6cb650a487
+sha256 = 95f7530e560d9eda0da6bf12b9d3453ac280add39609325567ee48570789bbc8

--- a/config/platforms/macos/x86_64/128.0.6613.84-1.ini
+++ b/config/platforms/macos/x86_64/128.0.6613.84-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-08-25T14:46:21.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_128.0.6613.84-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/128.0.6613.84-1.1/ungoogled-chromium_128.0.6613.84-1.1_x86-64-macos-signed.dmg
+md5 = b0d90fb4766bcca885451147fe26c28e
+sha1 = 313ba94843334c5f3bdc907672dd2514e10571ac
+sha256 = b7fa2f5869dfef4e8f4708df45745b38329c611632286a17d7ce3a3ee0f5c50c


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10547851383) by the release of [code-signed build 128.0.6613.84-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/128.0.6613.84-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/128.0.6613.84-1.1).