### PR TITLE
Add signed macOS builds of 128.0.6613.119-1.1

### DIFF
--- a/config/platforms/macos/arm64/128.0.6613.119-1.ini
+++ b/config/platforms/macos/arm64/128.0.6613.119-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-09-07T21:08:33.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_128.0.6613.119-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/128.0.6613.119-1.1/ungoogled-chromium_128.0.6613.119-1.1_arm64-macos-signed.dmg
+md5 = e9b8f36c785828952330343632769133
+sha1 = 53e9d6c0f2602708eced929aa58323f496075fe6
+sha256 = 268624985f3c591a514ce707ec04e345f0a7a3c2071f9e97e476490e96eb083f

--- a/config/platforms/macos/x86_64/128.0.6613.119-1.ini
+++ b/config/platforms/macos/x86_64/128.0.6613.119-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-09-07T21:08:33.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_128.0.6613.119-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/128.0.6613.119-1.1/ungoogled-chromium_128.0.6613.119-1.1_x86-64-macos-signed.dmg
+md5 = 570ffa3ed4f59ffe69ea140f3aeb53e4
+sha1 = aa2849a6352af29fc7f3ce0c02e307e289619831
+sha256 = d4f348402ee7c3715b77bb31dbb279aadf9189b3bad3219bd5a7c89f37676250


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10754440729) by the release of [code-signed build 128.0.6613.119-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/128.0.6613.119-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/128.0.6613.119-1.1).