### PR TITLE
Add signed macOS builds of 128.0.6613.137-1.1

### DIFF
--- a/config/platforms/macos/arm64/128.0.6613.137-1.ini
+++ b/config/platforms/macos/arm64/128.0.6613.137-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-09-13T11:27:56.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_128.0.6613.137-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/128.0.6613.137-1.1/ungoogled-chromium_128.0.6613.137-1.1_arm64-macos-signed.dmg
+md5 = c2b825775734cf7b7cb56d5e1bf43a89
+sha1 = fea72b3c2b26c27ec1a220cdee94040d811c729a
+sha256 = a5b319777341f7c8533916068155ec136199befa2e09c341f39c2c013c145b27

--- a/config/platforms/macos/x86_64/128.0.6613.137-1.ini
+++ b/config/platforms/macos/x86_64/128.0.6613.137-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-09-13T11:27:56.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_128.0.6613.137-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/128.0.6613.137-1.1/ungoogled-chromium_128.0.6613.137-1.1_x86-64-macos-signed.dmg
+md5 = 780357b905dd02fcf343d8b5a261d9db
+sha1 = 146fb228d784bfc596f54786367d707196d4ec77
+sha256 = d88c9d9669229c55d58135d722d007fea96a0ab4665a5d79119ec992edc0b39e


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10848287279) by the release of [code-signed build 128.0.6613.137-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/128.0.6613.137-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/128.0.6613.137-1.1).