### PR TITLE
Add signed macOS builds of 129.0.6668.58-1.1

### DIFF
--- a/config/platforms/macos/arm64/129.0.6668.58-1.ini
+++ b/config/platforms/macos/arm64/129.0.6668.58-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-09-23T15:31:11.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.58-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.58-1.1/ungoogled-chromium_129.0.6668.58-1.1_arm64-macos-signed.dmg
+md5 = 34569e2c09be6175b2bdcf5808f5cc50
+sha1 = 610475c3a375cc402a459c8ff31ab51f794391b6
+sha256 = 56eb749d3535a9387c70a65511ce393b3c2698502fa9d654a2c28b3580d61c49

--- a/config/platforms/macos/x86_64/129.0.6668.58-1.ini
+++ b/config/platforms/macos/x86_64/129.0.6668.58-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-09-23T15:31:11.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.58-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.58-1.1/ungoogled-chromium_129.0.6668.58-1.1_x86-64-macos-signed.dmg
+md5 = baab9a0508a14d2582fc9ad9e23adf03
+sha1 = 2b26c572faf2b0470c5ddd4373df3d88b3877944
+sha256 = ce6172afd95d12b932357c2f626498e8d5ba380e57725f7952a6d977b49d82cf


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/10997552000) by the release of [code-signed build 129.0.6668.58-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/129.0.6668.58-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/129.0.6668.58-1.1).