### PR TITLE
Add signed macOS builds of 129.0.6668.70-1.1

### DIFF
--- a/config/platforms/macos/arm64/129.0.6668.70-1.ini
+++ b/config/platforms/macos/arm64/129.0.6668.70-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-03T12:11:33.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.70-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.70-1.1/ungoogled-chromium_129.0.6668.70-1.1_arm64-macos-signed.dmg
+md5 = 32700d196905e9f7e58a6946eec6d80a
+sha1 = 51111c494861190a88f69fc493a5bea932fd1d1e
+sha256 = 4152bbe155b23741caf122cb24402c3d951127c6bb865078e11d907ff3a726af

--- a/config/platforms/macos/x86_64/129.0.6668.70-1.ini
+++ b/config/platforms/macos/x86_64/129.0.6668.70-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-03T12:11:33.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.70-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.70-1.1/ungoogled-chromium_129.0.6668.70-1.1_x86-64-macos-signed.dmg
+md5 = e179c1dd664122ee00a4ade07218f94b
+sha1 = 842dcdf0c894f81b1fb9b7c83cbedef126b80ee3
+sha256 = ed7c0b9c3b99396e7ccb084e737fa5b8c2c6ef39992a0d9d82127aff441b1820


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/11161744971) by the release of [code-signed build 129.0.6668.70-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/129.0.6668.70-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/129.0.6668.70-1.1).