### PR TITLE
Add signed macOS builds of 129.0.6668.89-1.1

### DIFF
--- a/config/platforms/macos/arm64/129.0.6668.89-1.ini
+++ b/config/platforms/macos/arm64/129.0.6668.89-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-05T22:46:04.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.89-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.89-1.1/ungoogled-chromium_129.0.6668.89-1.1_arm64-macos-signed.dmg
+md5 = 6990561b11b45de35c005d3fda51cd82
+sha1 = 097dd1ec4111ae0d35f66aacec2cdeaa9f1f88d5
+sha256 = 466cfa9901284a63ea6714c49570b3846fed9bc58f3c4bd089559c1b5c0569ad

--- a/config/platforms/macos/x86_64/129.0.6668.89-1.ini
+++ b/config/platforms/macos/x86_64/129.0.6668.89-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-05T22:46:04.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.89-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.89-1.1/ungoogled-chromium_129.0.6668.89-1.1_x86-64-macos-signed.dmg
+md5 = ea545d29c1f99581dbfd6dbec100e3f2
+sha1 = 1ba227efbb8b7845ae4fba07a29ed4aa0da3ff00
+sha256 = 4175716060e27859487582e6c54ab4831c99bca26f21b3829da46d9b0ed67e7a


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/11196874185) by the release of [code-signed build 129.0.6668.89-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/129.0.6668.89-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/129.0.6668.89-1.1).