### PR TITLE
Add signed macOS builds of 129.0.6668.100-1.1

### DIFF
--- a/config/platforms/macos/arm64/129.0.6668.100-1.ini
+++ b/config/platforms/macos/arm64/129.0.6668.100-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-12T19:46:36.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.100-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.100-1.1/ungoogled-chromium_129.0.6668.100-1.1_arm64-macos-signed.dmg
+md5 = 0be439fca4c8809f32b7b0699420c997
+sha1 = fcf345e867b8e1319ee8fabd0fe40751b5b7e990
+sha256 = ae11378c720c37ab4ccaa129c215898a47279a01cafbd586d2b30743a6bbb06d

--- a/config/platforms/macos/x86_64/129.0.6668.100-1.ini
+++ b/config/platforms/macos/x86_64/129.0.6668.100-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-12T19:46:36.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_129.0.6668.100-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/129.0.6668.100-1.1/ungoogled-chromium_129.0.6668.100-1.1_x86-64-macos-signed.dmg
+md5 = 5dcc96ab6da773eb0510cc2f8d1f05ff
+sha1 = 0ca51760454b953e286da9fd95960fb0ccc5d195
+sha256 = e45cad9598fd88affaf33ad63f20108722864b932d1908158da5010c44eead22


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/11308313698) by the release of [code-signed build 129.0.6668.100-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/129.0.6668.100-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/129.0.6668.100-1.1).