### PR TITLE
Add signed macOS builds of 130.0.6723.58-1.1

### DIFF
--- a/config/platforms/macos/arm64/130.0.6723.58-1.ini
+++ b/config/platforms/macos/arm64/130.0.6723.58-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-26T15:46:33.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_130.0.6723.58-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/130.0.6723.58-1.1/ungoogled-chromium_130.0.6723.58-1.1_arm64-macos-signed.dmg
+md5 = adc62ca92992bdae6e882e40c08fcafb
+sha1 = 26c80ee217581b875d61bb18fc83df2d6341482c
+sha256 = 930e83b1743ac9cb3bdb674f82ee2e43cda306ba41555d0329d523e64a7cd76e

--- a/config/platforms/macos/x86_64/130.0.6723.58-1.ini
+++ b/config/platforms/macos/x86_64/130.0.6723.58-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-26T15:46:33.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_130.0.6723.58-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/130.0.6723.58-1.1/ungoogled-chromium_130.0.6723.58-1.1_x86-64-macos-signed.dmg
+md5 = 7721d1f4bfc5b4c82284b468f0a802ab
+sha1 = 2097c005ad4d8feb4a37b8bc4c110fd3f4027092
+sha256 = 017361ef2e6bd845e702b56a769812c68082d9ee1106c2e365e327861bf7d067


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/11533051443) by the release of [code-signed build 130.0.6723.58-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/130.0.6723.58-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/130.0.6723.58-1.1).