### PR TITLE
Add signed macOS builds of 130.0.6723.69-1.1

### DIFF
--- a/config/platforms/macos/arm64/130.0.6723.69-1.ini
+++ b/config/platforms/macos/arm64/130.0.6723.69-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-28T10:09:19.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_130.0.6723.69-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/130.0.6723.69-1.1/ungoogled-chromium_130.0.6723.69-1.1_arm64-macos-signed.dmg
+md5 = 5f34f48901ac421dc50ae93bc63dc7f4
+sha1 = d72de3f57f0fcae7ea28f0f65666a05e9df1d84c
+sha256 = 7c4c91a8ceb68bee1a5c4733ca817b8dac9751009e510e7f711fe1184ed3562f

--- a/config/platforms/macos/x86_64/130.0.6723.69-1.ini
+++ b/config/platforms/macos/x86_64/130.0.6723.69-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-10-28T10:09:19.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_130.0.6723.69-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/130.0.6723.69-1.1/ungoogled-chromium_130.0.6723.69-1.1_x86-64-macos-signed.dmg
+md5 = b2808ec161a0111c0d1599efe5336ecf
+sha1 = b0e60945f72854031788706bc1f79488eeaa61ef
+sha256 = a73600c926302875c33623492272c461658ff89a6b4fa4b57b55b43e5de575ea


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/11551722129) by the release of [code-signed build 130.0.6723.69-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/130.0.6723.69-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/130.0.6723.69-1.1).