### PR TITLE
Add signed macOS builds of 130.0.6723.91-1.1

### DIFF
--- a/config/platforms/macos/arm64/130.0.6723.91-1.ini
+++ b/config/platforms/macos/arm64/130.0.6723.91-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-11-06T17:08:42.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_130.0.6723.91-1.1_arm64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/130.0.6723.91-1.1/ungoogled-chromium_130.0.6723.91-1.1_arm64-macos-signed.dmg
+md5 = f2121b6108b04ee9ef58978898cee46f
+sha1 = 8a54cee8ddeac8bd3a37ed9f61b433bb6a26b9c5
+sha256 = 94a216016bc9864d7cfa73389d4ab06d763f883bef6f8eca7ef9b33781da4506

--- a/config/platforms/macos/x86_64/130.0.6723.91-1.ini
+++ b/config/platforms/macos/x86_64/130.0.6723.91-1.ini
@@ -1,0 +1,10 @@
+[_metadata]
+publication_time = 2024-11-06T17:08:42.000000
+github_author = claudiodekker
+note = Automated code-signed/notarized builds of ungoogled-chromium for macOS.
+
+[ungoogled-chromium_130.0.6723.91-1.1_x86-64-macos-signed.dmg]
+url = https://github.com/claudiodekker/ungoogled-chromium-macos/releases/download/130.0.6723.91-1.1/ungoogled-chromium_130.0.6723.91-1.1_x86-64-macos-signed.dmg
+md5 = e82998d1ce3ef780658d70c3b21e0e3e
+sha1 = 38e386917afb54cfd8ce2d24122a80a02b941747
+sha256 = a24f05cdd8b29ccfebabc33dbacb5fb3ebad6b483e016151f7618fb97beb0e1f


### PR DESCRIPTION
This PR was [automatically triggered](https://github.com/claudiodekker/ungoogled-chromium-binaries/actions/runs/11708465145) by the release of [code-signed build 130.0.6723.91-1.1](https://github.com/claudiodekker/ungoogled-chromium-macos/releases/tag/130.0.6723.91-1.1) of ungoogled-chromium for macOS, which itself is based on [this ungoogled-software/ungoogled-chromium-macos build](https://github.com/ungoogled-software/ungoogled-chromium-macos/releases/tag/130.0.6723.91-1.1).